### PR TITLE
timecard: change of plan: do *not* put hourlies on timecards

### DIFF
--- a/media/windows/email-timecard-twice-month/email-timecard.py
+++ b/media/windows/email-timecard-twice-month/email-timecard.py
@@ -28,7 +28,7 @@ from email.message import EmailMessage
 
 smtp_server = 'smtp-relay.gmail.com'
 smtp_from   = 'Epiphany reminder <no-reply@epiphanycatholicchurch.org>'
-smtp_to     = 'staff@epiphanycatholicchurch.org,jimd@epiphanycatholicchurch.org,faith@feetwashers.org'
+smtp_to     = 'staff@epiphanycatholicchurch.org'
 subject     = 'Epiphany time card reminder'
 
 body        = '''


### PR DESCRIPTION
The hourly workers have a different timecard schedule than the
non-hourly workers.

Signed-off-by: Jeff Squyres <jeff@squyres.com>