### PR TITLE
PDSChurch.py: always return a list from find_*_email()

### DIFF
--- a/media/linux/pds-sqlite3-queries/sync-google-group.py
+++ b/media/linux/pds-sqlite3-queries/sync-google-group.py
@@ -369,8 +369,7 @@ def pds_find_ministry_emails(members, sync, log=None):
             _member_has_any_keyword(member, keywords)):
             em = PDSChurch.find_any_email(member)
             log.info("Found PDS email: {}".format(em))
-            if em:
-                emails.extend(em)
+            emails.extend(em)
 
     if log:
         log.info("PDS emails for ministries {m} and keywords {k}"

--- a/pds-queries/2018-summer-census-update/compare-jotform-results-to-pds.py
+++ b/pds-queries/2018-summer-census-update/compare-jotform-results-to-pds.py
@@ -323,18 +323,16 @@ def compare_members(google, start, end, pds_members, jotform_members):
 
         emails = PDSChurch.find_preferred_email(member)
         email = None
-        if emails:
-            for em in emails:
-                if em == row['Email']:
-                    email = em
-                    break
+        for em in emails:
+            if em == row['Email']:
+                email = em
+                break
         if email is None:
             emails = PDSChurch.find_any_email(member)
-            if emails:
-                for em in emails:
-                    if em == row['Email']:
-                        email = em + " (NOT PREFERRED)"
-                        break
+            for em in emails:
+                if em == row['Email']:
+                    email = em + " (NOT PREFERRED)"
+                    break
         _compare(changes, 'Preferred Email', row['Email'], email)
 
         phone = None

--- a/pds-queries/2018-summer-census-update/make-and-send-emails.py
+++ b/pds-queries/2018-summer-census-update/make-and-send-emails.py
@@ -368,8 +368,7 @@ def _send_family_emails(families, cookies, log=None):
         for m in f['members']:
             if _want_to_email_member(m):
                 em = PDSChurch.find_any_email(m)
-                if em:
-                    to_emails.extend(em)
+                to_emails.extend(em)
 
             if first:
                 log.info("=== Family: {name}".format(name=f['Name']))

--- a/python/PDSChurch.py
+++ b/python/PDSChurch.py
@@ -529,7 +529,7 @@ def find_preferred_email(member_or_family):
     if pkey in mof and len(mof[pkey]) > 0:
         return _get_sorted_addrs(mof[pkey])
     else:
-        return None
+        return [ ]
 
 # Return either the Member/Family preferred email addresses, or, if
 # there are no preferred addresses, return the first (by sorted order)
@@ -544,4 +544,4 @@ def find_any_email(member_or_family):
         addr = _get_sorted_addrs(mof[npkey])[0]
         return [ addr ]
     else:
-        return None
+        return [ ]


### PR DESCRIPTION
Don't return None if no emails are found; instead, return an empty
list.  This simplifies processing at the callers.

Signed-off-by: Jeff Squyres <jeff@squyres.com>