### PR TITLE
media/linux: systemd service to remove stale lockfile

### DIFF
--- a/media/linux/ecc-clear-pds-lockfile.service
+++ b/media/linux/ecc-clear-pds-lockfile.service
@@ -1,0 +1,40 @@
+# This is a systemd startup service file that will ensure that the PDS
+# synchronizer lock file is removed upon reboot (e.g., if the machine
+# freezes or is rebooted in the middle of a PDS synchronizer run).
+#
+# 1. Place a copy of this file in /etc/systemd/system
+# 2. Edit the file to reflect the correct directory where the lockfile
+#    is located (usually the home directory of the user owning the
+#    cron job that invokes the PDS synchronizer).
+# 3. sudo systemctl enable ecc-clear-pds-lockfile.service
+#
+# That's it.
+#
+# You can test the systemd service by:
+#
+#   touch /directory/of/lockfile/pds-run-all.lock
+#   sudo reboot
+#
+# And upon reboot, check to see if the lockfile is there.  If it's not
+# (and the cron job is not running!), then this systemd service worked
+# properly.
+#
+# You can also run the following to check its status:
+#
+#   sudo systemctl status ecc-clear-pds-lockfile.service
+#
+# It should show an either obviously happy or sad message about the
+# status of the service.
+
+[Unit]
+Description=Remove the ECC PDS synchronizer lockfile upon reboot
+DefaultDependencies=no
+Conflicts=shutdown.target
+After=local-fs.target
+
+[Service]
+ExecStart=/usr/bin/rm -f /home/itadmin/pds-run-all.lock
+Type=oneshot
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Upon machine reboot, remove the PDS synchronizer lockfile (just in
case the machine was rebooted/froze/whatever while the lockfile
was still present).

Signed-off-by: Jeff Squyres <jeff@squyres.com>