### PR TITLE
sync-google-group: fix debug argument

### DIFF
--- a/media/linux/pds-sqlite3-queries/sync-google-group.py
+++ b/media/linux/pds-sqlite3-queries/sync-google-group.py
@@ -725,7 +725,7 @@ def main():
     args = setup_cli_args()
 
     log = ECC.setup_logging(info=args.verbose,
-                            debug=args.verbose,
+                            debug=args.debug,
                             logfile=args.logfile)
 
     (pds, pds_families,


### PR DESCRIPTION
Only output debugging logging if --debug is specified.  A typo (or old
developement set?) was outputting debugging logging even when we only
specified --verbose (not --debug).

Signed-off-by: Jeff Squyres <jeff@squyres.com>