### PR TITLE
find-and-copy: ensure existing archive is removed

### DIFF
--- a/media/windows/copy-mp3s-to-google-drive/find-and-copy.py
+++ b/media/windows/copy-mp3s-to-google-drive/find-and-copy.py
@@ -610,7 +610,14 @@ def check_for_incoming_ftp():
         # Finally, move the file to the archive directory for a
         # "permanent" record (and so that we won't see it again on
         # future passes through this directory).
+        global archive_dir
+        archive_filename = os.path.join(archive_dir, file.filename)
+        log.info("Checking to make sure archive file does not already exist: {}".format(archive_filename))
+        if os.path.exists(archive_filename):
+            log.info("Removing already-existing archive file: {}".format(archive_filename))
+            os.remove(archive_filename)
         shutil.move(src=filename, dst=archive_dir)
+        log.info("Moved file to archive: {}".format(file.filename))
 
 ####################################################################
 #


### PR DESCRIPTION
If we have already copied the file to the archive (perhaps even
partially), remove it so that shutil.move() does not fail (it will fail
if the destination already exists).  I.e., we want to take the most
recent copy from incoming and put it in the archive.

Signed-off-by: Jeff Squyres <jeff@squyres.com>