### PR TITLE
sync-google: ignore backend Google errors

### DIFF
--- a/media/linux/pds-sqlite3-queries/sync-google-group.py
+++ b/media/linux/pds-sqlite3-queries/sync-google-group.py
@@ -444,6 +444,13 @@ def _sync_add(sync, group_permissions,
                               .format(email=email))
                 return None
 
+            elif err['reason'] == 'backendError':
+                if log:
+                    log.error("Google had an internal error while processing"
+                              "{email} -- ignoring"
+                              .format(email=email))
+                return None
+
             msg += " {msg} ({reason})".format(msg=err['message'],
                                               reason=err['reason'])
     except:


### PR DESCRIPTION
Suppress emailing notices about backend Google errors -- but still log
them.  These errors just happen periodically (a few times a week).
There's no need to alert ministry leaders about them -- they're
periodic errors and if there was any action to do, it'll just get
picked up the next time the script is run.

Signed-off-by: Jeff Squyres <jeff@squyres.com>