### PR TITLE
Batch file to backup files on \\media-o3020

### DIFF
--- a/media/windows/server-backups/google-backups.bat
+++ b/media/windows/server-backups/google-backups.bat
@@ -1,0 +1,14 @@
+rem The folder C:\Epiphany_backups is backed up to Google Drive via
+rem Google Backup and Sync.
+rem
+rem Once a day, via Windows Scheduled Tasks, run this script to
+rem robocopy sync a bunch of local folders to c:\Epiphany_backups
+rem so that they get synced / backed up to Google Drive.
+
+robocopy E:\ "C:\Epiphany_backups\dsx-e-thumb-drive" /mir /e /r:0 /w:0
+
+robocopy "C:\DSX 37151" "C:\Epiphany_Backups\DSX 37151" /mir /e /r:0 /w:0
+robocopy "C:\WinDSX" "C:\Epiphany_Backups\WinSX" /mir /e /r:0 /w:0
+
+robocopy "C:\PDSChurch\Data" "C:\Epiphany_Backups\PDSChurch\Data" /mir /e /r:0 /w:0
+robocopy "C:\PDSChurch\Backup" "C:\Epiphany_Backups\PDSChurch\Backup" /mir /e /r:0 /w:0


### PR DESCRIPTION
This script is run via the Windows Task Scheduler, once a day.  It
copies a bunch of folders from \\media-o3020 to C:\Epiphany_backups.
The C:\Epiphany_backups folder is synchronized out to Google Drive via
Google Backup and Sync.

Effectively, we're making a daily sync of these local folders to a
folder where Google Backup and Sync then synchronizes any changes up
to our backups in Google Drive.

Signed-off-by: Jeff Squyres <jeff@squyres.com>