### PR TITLE
Emit CSVs that can be imported into PDS

### DIFF
--- a/pds-queries/2019-fix-pds-photo-filenames/README.md
+++ b/pds-queries/2019-fix-pds-photo-filenames/README.md
@@ -1,0 +1,52 @@
+# Fixing PDS picture files
+
+In 2019, we moved the Z drive from \\fileengine to Google Shared
+Drives (i.e., G:\Shared Drives\ECC Public(Z)\PICTURES).
+
+Additionally, we consolidated a few picture folders that were in
+various places around Z into a single folder structure in the new
+Google Shared drive (all under the PICTURES folder, mentioned above).
+
+This resulted in making all the filenames in PDS -- for both Members
+and Families -- be stale.
+
+The python code in this directory is definitely not the prettiest code
+I've ever written, but it was for one-time use, and it was deemed
+"good enough" (e.g., the Member and Family code could certainly have
+been combined, and the whole Windows/Mac filesystem translation stuff
+could have been done much better / simpler).
+
+The idea was generally this:
+
+* For each Member / Family:
+  * If they have a Picture file
+    * Check to see if that file actually exists in the new Google
+      Shared Drive (i.e., run this on a machine that has the Google
+      Shared Drive mounted.  I ran this on a Mac, which made
+      things... complicated, because PDS wants Windows-style
+      filenames.)
+    * If the file exists, save an entry with the MID/FID (and name,
+      just for good measure) and the new Windows filename (based on
+      G:\Shared Drives\...etc.).
+
+* When done, output a "to-fix.csv" file with rows containing:
+  * The MID/FID
+  * The name
+  * The new filename
+
+Use the PDS "Import..." functionality to import this CSV for Members / Families.  Make sure to select:
+
+* Use Advanced Features
+* Update families/members only -- do not create
+* Use the MID/FID as the ID
+* Then go through and select the MID/FID column as the member/family index
+* And select the filename column as the picture filename
+
+Do a pre-import check to make sure it works (it should!).
+
+Then do the import.
+
+The Python also emitted "skipped.csv" to list all the filenames that
+it didn't fix.  There was only a dozen or two of these; I went through
+and found the ones that had relevant filenames in the Google Shared
+Drive and manually updated them in the PDS UI.

--- a/pds-queries/2019-fix-pds-photo-filenames/find-bad-picture-files.py
+++ b/pds-queries/2019-fix-pds-photo-filenames/find-bad-picture-files.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+
+import sys
+sys.path.insert(0, '../../python')
+
+import ECC
+import PDSChurch
+
+import re
+import os
+import csv
+import typing
+import pathlib
+import sqlite3
+import argparse
+
+from typing import List, Dict
+
+from pprint import pprint
+from pprint import pformat
+
+addr_fields = [ 'StreetAddress1',
+                'StreetAddress2',
+                'city_state',
+                'StreetZip' ]
+
+verbose = True
+debug   = False
+logfile = None
+
+old_member_base = "Z:\\2015-Pictorial-Directory-Photos\\"
+new_member_base = "G:\\Shared drives\\ECC Public (Z)\\PICTURES\\2015 Pictorial Directory"
+
+####################################################################
+#
+# Setup functions
+#
+####################################################################
+
+def setup_cli_args():
+    parser = argparse.ArgumentParser(description='Look for bad picture files')
+    parser.add_argument('--sqlite3',
+                        required=True,
+                        help='SQLite filename with PDS data')
+
+    parser.add_argument('--picture-dir',
+                        required=True,
+                        help='Directory where picture files are located')
+
+    parser.add_argument('--outfile',
+                        default='changes.csv',
+                        help='Name of CSV output file')
+
+    global verbose
+    parser.add_argument('--verbose',
+                        action='store_true',
+                        default=verbose,
+                        help='If enabled, emit extra status messages during run')
+    global debug
+    parser.add_argument('--debug',
+                        action='store_true',
+                        default=debug,
+                        help='If enabled, emit even more extra status messages during run')
+    global logfile
+    parser.add_argument('--logfile',
+                        default=logfile,
+                        help='Store verbose/debug logging to the specified file')
+
+    args = parser.parse_args()
+
+    # --debug implies --verbose
+    if args.debug:
+        args.verbose = True
+
+    # Make sure the files exist
+    if not os.path.exists(args.sqlite3):
+        print("ERROR: File not found: {f}".format(f=f))
+        exit(1)
+
+    return args
+
+####################################################################
+
+def read_pds(filename: str, log):
+    log.info("Reading {f}...".format(f=filename))
+
+    # We only care about parishioners, but we do want *all* Members --
+    # even if they're inactive (because we need to compare
+    # active-vs.-inactive, and inactive includes deceased).
+    (pds, families,
+     members) = PDSChurch.load_families_and_members(filename,
+                                                    active_only=False,
+                                                    parishioners_only=True,
+                                                    log=log)
+
+    pds.connection.close()
+
+    return families, members
+
+#-------------------------------------------------------------------
+
+def check_picturefiles(items: Dict, args: Dict, type: str, log) -> Dict:
+    count_filenames = 0
+    count_good      = 0
+    count_bad       = 0
+
+    bad = list()
+    for item in items.values():
+        field = 'PictureFile'
+        if field not in item:
+            continue
+
+        count_filenames = count_filenames + 1
+
+        # Filenames will be pathlib.PureWindowsPath objects
+        f = item[field]
+        log.debug("Got file: {}".format(f))
+
+        # If there's a Z: in the front, remove it
+        if f.drive == 'Z:':
+            log.debug("Parts of file: {}".format(pformat(f.parts)))
+            f = pathlib.PureWindowsPath(*f.parts[1:])
+            log.debug("Stripped Z: {}".format(f))
+
+        # Convert this to a file name on the local filesystem
+        log.debug("Parts: {}".format(f.parts))
+        native_filename = os.path.join(args.picture_dir, *list(f.parts))
+        if os.path.exists(native_filename):
+            log.debug("Exists! {}".format(native_filename))
+            count_good = count_good + 1
+        else:
+            log.warn("Does not exist: {}".format(native_filename))
+            bad.append(item)
+            count_bad = count_bad + 1
+
+    log.info("Results of scanning {type}:".format(type=type))
+    log.info("Total items:               {n}".format(n=len(items)))
+    log.info("Items with filenames:      {n}".format(n=count_filenames))
+    log.info("Items with good filenames: {n}".format(n=count_good))
+    log.info("Items with bad filenames:  {n}".format(n=count_bad))
+
+    return bad
+
+def check_member_picturefiles(members: Dict, args: Dict, bad: List,
+        log) -> None:
+    results = check_picturefiles(members, args, 'members', log)
+    for item in results:
+        bad.append({
+            'type'     : 'Member',
+            'id'       : item['MemRecNum'],
+            'name'     : item['full_name'],
+            'filename' : item['PictureFile'],
+        })
+
+def check_family_picturefiles(families: Dict, args: Dict, bad: List,
+        log) -> None:
+    results = check_picturefiles(families, args, 'families', log)
+    for item in results:
+        bad.append({
+            'type'     : 'Family',
+            'id'       : item['FamRecNum'],
+            'name'     : item['Name'],
+            'filename' : item['PictureFile'],
+        })
+
+####################################################################
+
+def output_results(filename: str, bad: List, log):
+    with open(filename, 'w') as csvfile:
+
+        fieldnames = ['Type', 'Unique ID', 'Name',
+                      'Bad filename']
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+
+        for item in bad:
+            type     = item['type']
+            id       = item['id']
+            name     = item['name']
+            filename = item['filename']
+            log.info("Bad filename: {type} {id} {name}: {filename}"
+                    .format(type=type,
+                            id=id,
+                            name=name,
+                            filename=filename))
+
+            writer.writerow({
+                'Type'         : type,
+                'Unique ID'    : id,
+                'Name'         : name,
+                'Bad filename' : filename,
+            })
+
+####################################################################
+
+def main() -> None:
+    args = setup_cli_args()
+
+    log = ECC.setup_logging(info=args.verbose,
+                            debug=args.debug,
+                            logfile=args.logfile,
+                            log_millisecond=False)
+
+    families, members = read_pds(args.sqlite3, log)
+
+    #---------------------------------------------------------------
+
+    bad = list()
+    check_member_picturefiles(members,  args, bad, log)
+    check_family_picturefiles(families, args, bad, log)
+
+    output_results(args.outfile, bad, log)
+
+    log.info("All done")
+
+if __name__ == '__main__':
+    main()

--- a/pds-queries/2019-fix-pds-photo-filenames/fix-family-picture-files.py
+++ b/pds-queries/2019-fix-pds-photo-filenames/fix-family-picture-files.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+
+import sys
+sys.path.insert(0, '../../python')
+
+import ECC
+import PDSChurch
+
+import re
+import os
+import csv
+import typing
+import pathlib
+import sqlite3
+import argparse
+
+from typing import List, Dict
+
+from pprint import pprint
+from pprint import pformat
+
+addr_fields = [ 'StreetAddress1',
+                'StreetAddress2',
+                'city_state',
+                'StreetZip' ]
+
+verbose = True
+debug   = False
+logfile = None
+
+family_bases = [
+{ 'old': r'Z:\\2015-Pictorial-Directory-Photos\\',
+  'new' : 'G:\\Shared drives\\ECC Public (Z)\\PICTURES\\2015 Pictorial Directory',
+  'local_prefix' : '2015 Pictorial Directory' },
+{ 'old': r'Z:\\PSA submitted photos\\',
+  'new' : 'G:\\Shared drives\\ECC Public (Z)\\PICTURES\\PSA submitted photos',
+  'local_prefix' : 'PSA submitted photos' },
+{ 'old': r'Z:\\Pictures\\Newcomer\'s Brunch Jan 2012\\',
+  'new' : 'G:\\Shared drives\\ECC Public (Z)\\PICTURES\\Newcomer\'s Brunch Jan 2012',
+  'local_prefix' : 'Newcomer\'s Brunch Jan 2012' },
+{ 'old': r'Z:\\Pictures\\Newcomer\'s brunch 4-2011\\',
+  'new' : 'G:\\Shared drives\\ECC Public (Z)\\PICTURES\\Newcomer\'s brunch 4-2011',
+  'local_prefix' : 'Newcomer\'s brunch 4-2011' },
+{ 'old': r'Z:\\Pictures\\Newcomer\'s brunch 7-2011\\',
+  'new' : 'G:\\Shared drives\\ECC Public (Z)\\PICTURES\\Newcomer\'s brunch 7-2011',
+  'local_prefix' : 'Newcomer\'s brunch 7-2011' },
+{ 'old': r'',
+  'new' : 'G:\\Shared drives\\ECC Public (Z)\\PICTURES\\2007 Pictorial Directory',
+  'local_prefix' : '2007 Pictorial Directory' },
+]
+
+####################################################################
+#
+# Setup functions
+#
+####################################################################
+
+def setup_cli_args():
+    parser = argparse.ArgumentParser(description='Look for bad picture files')
+    parser.add_argument('--sqlite3',
+                        required=True,
+                        help='SQLite filename with PDS data')
+
+    parser.add_argument('--picture-dir',
+                        required=True,
+                        help='Directory where picture files are located')
+
+    parser.add_argument('--outfile',
+                        default='changes.csv',
+                        help='Name of CSV output file')
+
+    global verbose
+    parser.add_argument('--verbose',
+                        action='store_true',
+                        default=verbose,
+                        help='If enabled, emit extra status messages during run')
+    global debug
+    parser.add_argument('--debug',
+                        action='store_true',
+                        default=debug,
+                        help='If enabled, emit even more extra status messages during run')
+    global logfile
+    parser.add_argument('--logfile',
+                        default=logfile,
+                        help='Store verbose/debug logging to the specified file')
+
+    args = parser.parse_args()
+
+    # --debug implies --verbose
+    if args.debug:
+        args.verbose = True
+
+    # Make sure the files exist
+    if not os.path.exists(args.sqlite3):
+        print("ERROR: File not found: {f}".format(f=f))
+        exit(1)
+
+    return args
+
+####################################################################
+
+def read_pds(filename: str, log):
+    log.info("Reading {f}...".format(f=filename))
+
+    # We only care about parishioners, but we do want *all* Members --
+    # even if they're inactive (because we need to compare
+    # active-vs.-inactive, and inactive includes deceased).
+    (pds, families,
+     members) = PDSChurch.load_families_and_members(filename,
+                                                    active_only=False,
+                                                    parishioners_only=True,
+                                                    log=log)
+
+    pds.connection.close()
+
+    return families, members
+
+#-------------------------------------------------------------------
+
+def check_family_picturefiles(families, args, log):
+    def _doit(old, new, local_prefix):
+        print("Checking: {file}".format(file=f[field]))
+        match_str = r'^{base}(.+)$'.format(base=old)
+        parts = re.match(match_str, str(f[field]))
+        if not parts:
+            return False
+
+        filename = parts.group(1)
+        print("Found filename: " + filename)
+
+        # If the file exists in the picture dir, update it
+        local_filename = filename.replace('\\', '/')
+        local_abs_filename = os.path.join(args.picture_dir, local_prefix, local_filename)
+        print("Checking local filename: " + local_abs_filename)
+        if os.path.exists(local_abs_filename):
+            print("==> Good filename.  Will update.")
+            record['filename'] = "{new}\\{filename}".format(new=new, filename=filename)
+            return True
+        else:
+            print("--> Bad filename.  Skipped")
+            return False
+
+    to_fix = list()
+    skipped = list()
+    field = 'PictureFile'
+
+    for f in families.values():
+        if field not in f:
+            continue
+
+        record = {
+            'fid' : f['FamRecNum'],
+            'name' : f['Name'],
+            'filename' : str(f[field])
+        }
+
+        for base in family_bases:
+            ret = _doit(base['old'], base['new'], base['local_prefix'])
+            if ret:
+                to_fix.append(record)
+                break
+        if not ret:
+            skipped.append(record)
+
+    return to_fix, skipped
+
+####################################################################
+
+def output_results(to_fix, skipped, log):
+    def _do_write(filename, items):
+        with open(filename, 'w') as csvfile:
+            fieldnames = ['FID', 'Name', 'Filename']
+            writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+            writer.writeheader()
+
+            for item in items:
+                fid      = item['fid']
+                name     = item['name']
+                filename = item['filename']
+                log.info("New filename: {fid} {name}: {filename}"
+                        .format(fid=fid,
+                                name=name,
+                                filename=filename))
+
+                writer.writerow({
+                    'FID'          : fid,
+                    'Name'         : name,
+                    'Filename'     : filename,
+                })
+
+    _do_write("to_fix.csv", to_fix)
+    _do_write("skipped.csv", skipped)
+
+####################################################################
+
+def main() -> None:
+    args = setup_cli_args()
+
+    log = ECC.setup_logging(info=args.verbose,
+                            debug=args.debug,
+                            logfile=args.logfile,
+                            log_millisecond=False)
+
+    families, members = read_pds(args.sqlite3, log)
+
+    #---------------------------------------------------------------
+
+    to_fix, skipped = check_family_picturefiles(families, args, log)
+    output_results(to_fix, skipped, log)
+
+    log.info("All done")
+
+if __name__ == '__main__':
+    main()

--- a/pds-queries/2019-fix-pds-photo-filenames/fix-member-picture-files.py
+++ b/pds-queries/2019-fix-pds-photo-filenames/fix-member-picture-files.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+
+import sys
+sys.path.insert(0, '../../python')
+
+import ECC
+import PDSChurch
+
+import re
+import os
+import csv
+import typing
+import pathlib
+import sqlite3
+import argparse
+
+from typing import List, Dict
+
+from pprint import pprint
+from pprint import pformat
+
+addr_fields = [ 'StreetAddress1',
+                'StreetAddress2',
+                'city_state',
+                'StreetZip' ]
+
+verbose = True
+debug   = False
+logfile = None
+
+old_member_base = r'Z:\\2015-Pictorial-Directory-Photos'
+new_member_base = "G:\\Shared drives\\ECC Public (Z)\\PICTURES\\2015 Pictorial Directory"
+
+####################################################################
+#
+# Setup functions
+#
+####################################################################
+
+def setup_cli_args():
+    parser = argparse.ArgumentParser(description='Look for bad picture files')
+    parser.add_argument('--sqlite3',
+                        required=True,
+                        help='SQLite filename with PDS data')
+
+    parser.add_argument('--picture-dir',
+                        required=True,
+                        help='Directory where picture files are located')
+
+    parser.add_argument('--outfile',
+                        default='changes.csv',
+                        help='Name of CSV output file')
+
+    global verbose
+    parser.add_argument('--verbose',
+                        action='store_true',
+                        default=verbose,
+                        help='If enabled, emit extra status messages during run')
+    global debug
+    parser.add_argument('--debug',
+                        action='store_true',
+                        default=debug,
+                        help='If enabled, emit even more extra status messages during run')
+    global logfile
+    parser.add_argument('--logfile',
+                        default=logfile,
+                        help='Store verbose/debug logging to the specified file')
+
+    args = parser.parse_args()
+
+    # --debug implies --verbose
+    if args.debug:
+        args.verbose = True
+
+    # Make sure the files exist
+    if not os.path.exists(args.sqlite3):
+        print("ERROR: File not found: {f}".format(f=f))
+        exit(1)
+
+    return args
+
+####################################################################
+
+def read_pds(filename: str, log):
+    log.info("Reading {f}...".format(f=filename))
+
+    # We only care about parishioners, but we do want *all* Members --
+    # even if they're inactive (because we need to compare
+    # active-vs.-inactive, and inactive includes deceased).
+    (pds, families,
+     members) = PDSChurch.load_families_and_members(filename,
+                                                    active_only=False,
+                                                    parishioners_only=True,
+                                                    log=log)
+
+    pds.connection.close()
+
+    return families, members
+
+#-------------------------------------------------------------------
+
+def check_member_picturefiles(members, args, log):
+    to_fix = list()
+    skipped = list()
+
+    match_str = r'^{base}\\(.+)$'.format(base=old_member_base)
+    prog = re.compile(r'^Z:\\2015-Pictorial-Directory-Photos\\(.+)$')
+    field = 'PictureFile'
+
+    for m in members.values():
+        if field not in m:
+            continue
+
+        record = {
+            'mid' : m['MemRecNum'],
+            'name' : m['full_name'],
+            'filename' : str(m[field])
+        }
+
+        # Low hanging fruit: just look for files starting with:
+        # Z:\2015-Pictorial-Directory-Photos
+        # and replace them with a prefix of:
+        # G:\Shared drives\ECC Public (Z)\PICTURES\2015 Pictorial Directory
+        print("Checking: {file}".format(file=m[field]))
+        parts = prog.match(str(m[field]))
+        if not parts:
+            skipped.append(record)
+            continue
+
+        filename = parts.group(1)
+        print("Found filename: " + filename)
+
+        # If the file exists in the picture dir, update it
+        local_filename = os.path.join(args.picture_dir, filename)
+        print("Checking local filename: " + local_filename)
+        if os.path.exists(local_filename):
+            print("==> Good filename.  Will update.")
+            record['filename'] = os.path.join(new_member_base, filename)
+            to_fix.append(record)
+        else:
+            print("--> Bad filename.  Skipped")
+            skipped.append(record)
+
+    return to_fix, skipped
+
+####################################################################
+
+def output_results(to_fix, skipped, log):
+    def _do_write(filename, items):
+        with open(filename, 'w') as csvfile:
+            fieldnames = ['MID', 'Name', 'Filename']
+            writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+            writer.writeheader()
+
+            for item in items:
+                mid      = item['mid']
+                name     = item['name']
+                filename = item['filename']
+                log.info("New filename: {mid} {name}: {filename}"
+                        .format(mid=mid,
+                                name=name,
+                                filename=filename))
+
+                writer.writerow({
+                    'MID'          : mid,
+                    'Name'         : name,
+                    'Filename' : filename,
+                })
+
+    _do_write("to_fix.csv", to_fix)
+    _do_write("skipped.csv", skipped)
+
+####################################################################
+
+def main() -> None:
+    args = setup_cli_args()
+
+    log = ECC.setup_logging(info=args.verbose,
+                            debug=args.debug,
+                            logfile=args.logfile,
+                            log_millisecond=False)
+
+    families, members = read_pds(args.sqlite3, log)
+
+    #---------------------------------------------------------------
+
+    to_fix, skipped = check_member_picturefiles(members, args, log)
+    output_results(to_fix, skipped, log)
+
+    log.info("All done")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Fix PDS Member/Family photo filenames to reflect moving the "Z" drive
from \\fileengine (which was mapped to "Z:\" on all machines) to a
Google Shared Drive.  Do this by emitting a CSV with the new filename
location, mapped to a PDS Member MID or PDS Member FID, respectively.

See the README.md for more information.

Signed-off-by: Jeff Squyres <jeff@squyres.com>