### PR TITLE
export-pds: do backups at <= 12:14am

### DIFF
--- a/media/linux/export-pds-into-sqlite/run.sh
+++ b/media/linux/export-pds-into-sqlite/run.sh
@@ -22,7 +22,7 @@ cd $prog_dir
 # If this is the first run after midnight, save a copy for archival
 # purposes.
 t=`date '+%H%M'`
-yes=`expr $t \< 5`
+yes=`expr $t \<= 14`
 if test $yes -eq 1; then
     # Upload some files to a Google drive
     archive_dir="`readlink -f $sqlite_out_dir/archives`"


### PR DESCRIPTION
With the addition of more data exported from PDS, it was taking longer
than 5 minutes to finish, and the test for checking for "< 12:05am"
was never succeeding, and PDS data was not being backed up to Google
Drive.

So expand this test to check for "<= 12:14am".  This should be more
than enough to make sure that the backups now actually run.  Our PDS
exports run every 15 minutes, so this is still a safe test.

Signed-off-by: Jeff Squyres <jeff@squyres.com>