### PR TITLE
Updates for media-o5070

### DIFF
--- a/media/windows/copy-mp3s-to-google-drive/find-and-copy.py
+++ b/media/windows/copy-mp3s-to-google-drive/find-and-copy.py
@@ -56,7 +56,6 @@ Note that this script works on Windows, Linux, and OS X.  But first,
 you need to install some Python classes:
 
     pip install --upgrade google-api-python-client
-    pip install --upgrade recordclass
 
 Regarding Google Drive / Google Python API documentation:
 
@@ -98,7 +97,6 @@ import logging.handlers
 import traceback
 import shutil
 from email.message import EmailMessage
-from recordclass import recordclass
 
 from pprint import pprint
 
@@ -140,18 +138,20 @@ debug = False
 logfile = "log.txt"
 file_stable_secs = 60
 
-ScannedFile = recordclass('ScannedFile',
-                         ['filename',
-                          'year',
-                          'month',
-                          'size',
-                          'mtime',
-                          'uploaded'])
+class ScannedFile:
+    def __init__(filename, year, month, size, mtime, uploaded):
+        self.filename = filename
+        self.year     = year
+        self.month    = month
+        self.size     = size
+        self.mtime    = mtime
+        self.uploaded = uploaded
 
-GTDFile = recordclass('GTDFile',
-                      ['scannedfile',
-                       'folder_webviewlink',
-                       'file_webviewlink'])
+class GTDFile:
+    def __init__(scannedfile, folder_webviewlink, file_webviewlink):
+        self.scannedfile        = scannedfile
+        self.folder_webviewlink = folder_webviewlink
+        self.file_webviewlink   = file_webviewlink
 
 #-------------------------------------------------------------------
 

--- a/media/windows/internet-connectivity-checker/internet-connectivity-checker.py
+++ b/media/windows/internet-connectivity-checker/internet-connectivity-checker.py
@@ -10,7 +10,7 @@ import http.client
 import urllib.parse
 
 last_state = None
-external_url = "https://status.github.com/api/status.json"
+external_url = "https://www.githubstatus.com/"
 timestamp_format = "%m/%d/%Y %H:%M:%S"
 
 # Hand-set values from the Google Form
@@ -51,7 +51,7 @@ def submit_google_form(outage_start, outage_end):
                      body=body,
                      headers=headers)
         response = conn.getresponse()
-        if response and response.status == 200:
+        if response and response.status >= 200 and response.status < 400:
             return True
     except:
         # If we get an exception, just fall through so that all errors


### PR DESCRIPTION
The "recordclass" module is proving difficult to install with Python
3.8.1 and Visual Studio 19 on the media-o5020 server.  So just stop
using recordclass and use a regular Python class, instead.

Signed-off-by: Jeff Squyres <jeff@squyres.com>