### PR TITLE
Move PDS data to the "new" media server

### DIFF
--- a/media/linux/etc/README.md
+++ b/media/linux/etc/README.md
@@ -21,10 +21,7 @@ manually!).
 Don't forget to add pinholes in the Windows firewall for ssh and
 postfix (TCP/22 and TCP/25, respectively).
 
-We also do two other actions in this same Task Manager entry:
+We also do other actions in this same Task Manager entry:
 
 1. Remove the export-PDS-data file lock (if it's still there).
    This is just a failsafe.
-2. Mount the \\media-o3020\pdschurch on /mnt/pdschurch.
-   This is temporary and will go away when the PDS Church data
-   is moved to this new server.

--- a/media/linux/etc/sudoers
+++ b/media/linux/etc/sudoers
@@ -33,4 +33,3 @@ root	ALL=(ALL:ALL) ALL
 %sudo ALL=NOPASSWD: /etc/init.d/cron start
 %sudo ALL=NOPASSWD: /etc/init.d/postfix start
 %sudo ALL=NOPASSWD: /etc/init.d/ssh start
-%sudo ALL=NOPASSWD: /bin/mount

--- a/media/linux/export-pds-into-sqlite/run.sh
+++ b/media/linux/export-pds-into-sqlite/run.sh
@@ -1,14 +1,8 @@
 #!/bin/zsh
-#
-# In WSL:
-#
-# sudo mkdir /mnt/pdschurch
-# sudo mount -t drvfs '\\media-o3020\pdschurch' /mnt/pdschurch
-#
 
 set -x
 
-pds_input_dir=/mnt/pdschurch/Data
+pds_input_dir=/mnt/c/pdschurch/Data
 
 base=/home/coeadmin/git/epiphany/media/linux
 prog_dir=$base/export-pds-into-sqlite


### PR DESCRIPTION
The "new" media server has become media-o3020 (even though it is an
Optiplex 5070, not a 3020 -- but we chose to keep the old name rather
than update it everywhere that name is used).  So now the Linux Python
on this server can access the files directly through /mnt/c (not a
network share mount).

Signed-off-by: Jeff Squyres <jeff@squyres.com>