### PR TITLE
BLS:  Make sure the ".exit" command is on it's on line.

### DIFF
--- a/media/linux/export-pds-into-sqlite/export-pdschurchoffice-to-sqlite3.py
+++ b/media/linux/export-pds-into-sqlite/export-pdschurchoffice-to-sqlite3.py
@@ -356,7 +356,7 @@ def process_db(args, db, sqlite3):
 
 # Close down sqlite3
 def close_sqlite3(sqlite3):
-    sqlite3.stdin.write('.exit\n')
+    sqlite3.stdin.write('\n.exit\n')
     sqlite3.communicate()
 
 # Rename the temp database to the final database name


### PR DESCRIPTION
In my WSL environment the .exit command throws a syntax error if it is not on a line by itself.  Media might throw an error too.
If the last DB processed creates a transaction, then it will do an 'END TRANSACTION;\n'.  The \n will put the .exit on the next line and it works.  But, if the last DB drops out from the skip/ignore cases, then the .exit will be on the same line (causing a syntax error).  In either case, the extra newline is just white space and ignore during SQL processing.

Signed-off-by: Bruce Schweinhart <bswine2@gmail.com>
