### PR TITLE
Postfix: add more docs / explanation

### DIFF
--- a/media/linux/etc/postfix/README.md
+++ b/media/linux/etc/postfix/README.md
@@ -7,14 +7,27 @@ relays out to smtp.gmail.com for the actual delivery.
 
 We use the "konica-minolta@epiphanycatholicchurch.org" G Suite user to
 send these emails (i.e., the "from" address corresponds to a real G
-Suite account so that we can set to use "less secure apps" on that
-account).  Note that it was necessary to generate an app-specifici
-password for the konica-minolta@ecc user (which isn't saved in lastpass)
-because that user uses 2FA.  If this password is lost, just delete it
-and re-generate a new one.
+Suite account; we also had to set to allow "less secure apps" on that
+account -- THIS MAY STOP WORKING SOMEDAY!  I.e., Google may stop
+allowing "less secure apps", in which case we'll have to figure out a
+new solution.  Hopefully we'll have a new copier that can legit send
+emails via Gmail by that point, and this won't be necessary!).  Note
+that it was necessary to generate an app-specific password for the
+konica-minolta@ecc user (which isn't saved in lastpass) because that
+user uses 2FA.  If this password is lost, just delete it and
+re-generate a new one.
 
-See the "Epiphany" and "ECC" comments in this file for more details
-about:
+Additionally, it looks like Google may periodically expire the 2FA/app
+specific password.  When that happens, the mail will stop flowing
+because Postfix will fail to SASL authenticate to smtp.gmail.com (this
+will be evident in the /var/log/mail.* logs).  Just login as
+konica-minolta@ecc.org, go to the security settings on the account and
+create a new app specific password.  Then follow the instructions in
+the comments in these files for how to reset the Postfix config with
+the new app specific password.
+
+See the "Epiphany" and "ECC" comments in the files in this folder for
+more details about:
 
 * exactly what settings were changed from the postfix defaults
 * additional commands that were run (e.g., to setup the SASL password)

--- a/media/linux/etc/postfix/main.cf
+++ b/media/linux/etc/postfix/main.cf
@@ -44,8 +44,10 @@ smtp_sasl_auth_enable = yes
 # NOTE: The PASSWORD may need to be an app-specific password if the
 # account uses 2FA.
 #
-# after editing, must run: postmap /etc/postfix/sasl/konica-minolta-passwd
-# Google requires "Allow less secure apps" on the account used
+# After editing, must run: postmap /etc/postfix/sasl/konica-minolta-passwd
+# Google requires "Allow less secure apps" on the account used.
+# You may also need to run: service postfix reload
+# You can force any pending emails to try sending again via: postfix flush
 smtp_sasl_password_maps = hash:/etc/postfix/sasl/konica-minolta-passwd
 
 # Epiphany / ECC


### PR DESCRIPTION
Add some more documentation and explanation on the Postfix setup for
relaying out to Gmail.

Signed-off-by: Jeff Squyres <jeff@squyres.com>