### PR TITLE
sync-google: use SMTP AUTH for sending email

### DIFF
--- a/media/linux/.gitignore
+++ b/media/linux/.gitignore
@@ -1,2 +1,2 @@
-logfile.txt
+logfile.txt*
 pds-data

--- a/media/linux/pds-sqlite3-queries/.gitignore
+++ b/media/linux/pds-sqlite3-queries/.gitignore
@@ -1,3 +1,7 @@
 mailman-*
 sync-mailman-logfile.txt*
 sync-google-group-logfile.txt*
+
+client_id.json
+user-credentials.json
+smtp-auth.txt

--- a/media/linux/pds-sqlite3-queries/run.sh
+++ b/media/linux/pds-sqlite3-queries/run.sh
@@ -22,7 +22,11 @@ cd $prog_dir
 
 # Generate the list of email addresses from PDS data and sync
 google_logfile=$prog_dir/sync-google-group-logfile.txt
+tokens=`cat smtp-auth.txt`
+username=`echo $tokens | cut -d: -f1`
+password=`echo $tokens | cut -d: -f2`
 ./sync-google-group.py \
+    --smtp smtp-relay.gmail.com no-reply@epiphanycatholicchurch.org $username $password \
     --sqlite3-db=$sqlite_dir/pdschurch.sqlite3 \
     --logfile=$google_logfile \
     --verbose


### PR DESCRIPTION
We don't pay for a static IP address at ECC, and over the past several
weeks, it has changed several times.  As such, mails stopped flowing
until we noticed the IP address change and updated Google config to
match the new IP.

Instead of relying on a fixed/whitelisted IP address, use SMTP AUTH to
login with a valid set of ECC Google Account credentials, which will
allow us to send then send from *any* @epiphanycatholicchurch.org
email address.

NOTE: The Google Account email address used to SMTP AUTH must specify
a 2FA app-specific password as the SMTP AUTH password.  I.e., go to
that ECC Google Account in the Security setup and setup an
app-specific password, and then use that app-specific password here.

Signed-off-by: Jeff Squyres <jeff@squyres.com>