### PR TITLE
Convert all Python to SMTP AUTH

### DIFF
--- a/media/linux/pds-sqlite3-queries/run.sh
+++ b/media/linux/pds-sqlite3-queries/run.sh
@@ -22,11 +22,8 @@ cd $prog_dir
 
 # Generate the list of email addresses from PDS data and sync
 google_logfile=$prog_dir/sync-google-group-logfile.txt
-tokens=`cat smtp-auth.txt`
-username=`echo $tokens | cut -d: -f1`
-password=`echo $tokens | cut -d: -f2`
 ./sync-google-group.py \
-    --smtp smtp-relay.gmail.com no-reply@epiphanycatholicchurch.org $username $password \
+    --smtp-auth-file $HOME/smtp-auth.txt \
     --sqlite3-db=$sqlite_dir/pdschurch.sqlite3 \
     --logfile=$google_logfile \
     --verbose

--- a/media/windows/copy-mp3s-to-google-drive/find-and-copy.py
+++ b/media/windows/copy-mp3s-to-google-drive/find-and-copy.py
@@ -170,6 +170,18 @@ def send_mail(subject, message_body, html=False):
         if args.debug:
             smtp.set_debuglevel(2)
 
+        # This assumes that the file has a single line in the format of username:password.
+        with open(args.smtp_auth_file) as f:
+            line = f.read()
+            smtp_username, smtp_password = line.split(':')
+
+        # Login; we can't rely on being IP whitelisted.
+        try:
+            smtp.login(smtp_username, smtp_password)
+        except Exception as e:
+            log.error(f'Error: failed to SMTP login: {e}')
+            exit(1)
+
         msg = EmailMessage()
         msg.set_content(message_body)
         msg['Subject'] = subject
@@ -664,6 +676,9 @@ def add_cli_args():
                                  nargs=3,
                                  required=False,
                                  help='SMTP server hostname, to, and from addresses')
+    tools.argparser.add_argument('--smtp-auth-file',
+                                 required=True
+                                 help='File containing SMTP AUTH username:password')
 
     tools.argparser.add_argument('--data-dir',
                                  required=False,

--- a/media/windows/email-patch-tuesday/patch-tuesday.py
+++ b/media/windows/email-patch-tuesday/patch-tuesday.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Send a simple automated email.
@@ -23,6 +23,7 @@
 #
 
 import smtplib
+import argparse
 
 from email.message import EmailMessage
 
@@ -30,6 +31,17 @@ smtp_server = 'smtp-relay.gmail.com'
 smtp_from   = 'Epiphany reminder <no-reply@epiphanycatholicchurch.org>'
 smtp_to     = 'staff@epiphanycatholicchurch.org,itadmin@epiphanycatholicchurch.org'
 subject     = 'Epiphany patch Tuesday reminder'
+
+parser = argparse.ArgumentParser(description='Patch Tuesday email sender')
+parser.add_argument(f'--smtp-auth-file',
+                    required=True,
+                    help='File containing SMTP AUTH username:password for {smtp_server}')
+args = parser.parse_args()
+
+# This assumes that the file has a single line in the format of username:password.
+with open(args.smtp_auth_file) as f:
+    line = f.read()
+    smtp_username, smtp_password = line.split(':')
 
 body        = '''<h1>REMINDER!</h1>
 
@@ -57,6 +69,13 @@ Myrador</p>'''
 with smtplib.SMTP_SSL(host=smtp_server) as smtp:
     msg = EmailMessage()
     msg.set_content(body)
+
+    # Login; we can't rely on being IP whitelisted.
+    try:
+        smtp.login(smtp_username, smtp_password)
+    except Exception as e:
+        log.error(f'Error: failed to SMTP login: {e}')
+        exit(1)
 
     msg['From']    = smtp_from
     msg['To']      = smtp_to

--- a/media/windows/email-timecard-twice-month/email-timecard.py
+++ b/media/windows/email-timecard-twice-month/email-timecard.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Send a simple automated email.
@@ -23,6 +23,7 @@
 #
 
 import smtplib
+import argparse
 
 from email.message import EmailMessage
 
@@ -30,6 +31,17 @@ smtp_server = 'smtp-relay.gmail.com'
 smtp_from   = 'Epiphany reminder <no-reply@epiphanycatholicchurch.org>'
 smtp_to     = 'staff@epiphanycatholicchurch.org'
 subject     = 'Epiphany time card reminder'
+
+parser = argparse.ArgumentParser(description='Patch Tuesday email sender')
+parser.add_argument(f'--smtp-auth-file',
+                    required=True,
+                    help='File containing SMTP AUTH username:password for {smtp_server}')
+args = parser.parse_args()
+
+# This assumes that the file has a single line in the format of username:password.
+with open(args.smtp_auth_file) as f:
+    line = f.read()
+    smtp_username, smtp_password = line.split(':')
 
 body        = '''
 <p>Please complete and turn in timesheets the first working day
@@ -45,6 +57,13 @@ Teddy</p>'''
 with smtplib.SMTP_SSL(host=smtp_server) as smtp:
     msg = EmailMessage()
     msg.set_content(body)
+
+    # Login; we can't rely on being IP whitelisted.
+    try:
+        smtp.login(smtp_username, smtp_password)
+    except Exception as e:
+        log.error(f'Error: failed to SMTP login: {e}')
+        exit(1)
 
     msg['From']    = smtp_from
     msg['To']      = smtp_to


### PR DESCRIPTION
Missed a bunch of other scripts that require converting to use SMTP
AUTH.  Change all of them to accept an --smtp-auth-file FILENAME
argument; the file is assumed to be a single line long and of the
format "username:password", where:

* username: ECC Google Account to use to login
* password: 2FA app-specific password for that account

Signed-off-by: Jeff Squyres <jeff@squyres.com>