### PR TITLE
smtp gmail postfix: update notes

### DIFF
--- a/media/linux/etc/postfix/README.md
+++ b/media/linux/etc/postfix/README.md
@@ -3,7 +3,7 @@ server.  This postfix server is mainly running to act as a relay from
 the Konica Minolta copier to our Gmail SMTP servers.  The firmware
 running on the Konica is too old to understand modern TLS protocol.
 So we have the Konica submit to this local Postfix server, which then
-relays out to smtp.gmail.com for the actual delivery.
+relays out to smtp-relay.gmail.com for the actual delivery.
 
 We use the "konica-minolta@epiphanycatholicchurch.org" G Suite user to
 send these emails (i.e., the "from" address corresponds to a real G
@@ -19,12 +19,26 @@ re-generate a new one.
 
 Additionally, it looks like Google may periodically expire the 2FA/app
 specific password.  When that happens, the mail will stop flowing
-because Postfix will fail to SASL authenticate to smtp.gmail.com (this
+because Postfix will fail to SASL authenticate to smtp-relay.gmail.com (this
 will be evident in the /var/log/mail.* logs).  Just login as
 konica-minolta@ecc.org, go to the security settings on the account and
 create a new app specific password.  Then follow the instructions in
 the comments in these files for how to reset the Postfix config with
 the new app specific password.
+
+***UPDATE 2020 AUGUST:*** We stopped allowlisting Epiphany's IP
+   address in the G Suite dashboard because we don't pay for a fixed
+   IP address, and Spectrum kept changing it on us.  Instead, we're
+   now using SMTP SASL AUTH authentication (which works no matter what
+   IP address you're coming from).  As such, we updated the SMTP
+   hostname to `smtp-relay.gmail.com`, which accepts authentication on
+   port 587 (which is what we have Postfix configured to do).
+
+***UPDATE 2020 AUGUST:*** The irony is that we updated to SMTP SASL
+   AUTH right before we replaced the Konica with a modern Ricoh model
+   that can natively email to Google, and this SMTP relay is no longer
+   necessary for Konica scans.  We may still want this email relay for
+   other reasons, though -- TBD.
 
 See the "Epiphany" and "ECC" comments in the files in this folder for
 more details about:

--- a/media/linux/etc/postfix/main.cf
+++ b/media/linux/etc/postfix/main.cf
@@ -39,7 +39,7 @@ smtp_sasl_auth_enable = yes
 # path to password map file
 # Format of the file is:
 #
-# [smtp.gmail.com]:587  konica-minolta@epiphanycatholicchurch.org:PASSWORD
+# [smtp-relay.gmail.com]:587  konica-minolta@epiphanycatholicchurch.org:PASSWORD
 #
 # NOTE: The PASSWORD may need to be an app-specific password if the
 # account uses 2FA.
@@ -70,7 +70,7 @@ alias_database = hash:/etc/aliases
 myorigin = /etc/mailname
 mydestination = $myhostname, media-o5070.localdomain, localhost.localdomain, , localhost
 # Epiphany / ECC: Relay to gmail
-relayhost = [smtp.gmail.com]:587
+relayhost = [smtp-relay.gmail.com]:587
 # Epiphany / ECC: explicitly add in epiphanycatholicchurch.org
 relay_domains = epiphanycatholicchurch.org
 # Epiphany / ECC: explicitly state that there are no local recipient maps


### PR DESCRIPTION
Update comments and notes about how we relay email out to
smtp-relay.gmail.com from the media server WSL Ubutunu instance.

Signed-off-by: Jeff Squyres <jeff@squyres.com>