### PR TITLE
PDSChurch.py: support Family "Visitor" field

### DIFF
--- a/python/PDSChurch.py
+++ b/python/PDSChurch.py
@@ -107,6 +107,7 @@ def _load_families(pds, columns=None,
     columns.append('StatDescRec')
     columns.append('PictureFile')
     columns.append('EnvelopeUser')
+    columns.append('Visitor')
     columns.append('PDSInactive{num}'.format(num=db_num))
 
     where = ('Fam_DB.CensusFamily{db_num}=1'
@@ -207,7 +208,7 @@ def _delete_non_parishioners(families, members):
     # Look for family ParKey >= 10,000
     for fid, f in families.items():
         parkey = int(f['ParKey'])
-        if parkey >= 10000:
+        if parkey >= 10000 or f['Visitor']:
             f = families[fid]
             for m in f['members']:
                 mid = m['MemRecNum']


### PR DESCRIPTION
This field corresponds to the "Non-parishioner" checkbox in PDS10.
This is a Family field, not a Member field.

When reading the PDS SQLite3 database, filter non-parishioners if
their envelope number is > 10,000 *or* if their Visitor value is
true.

Signed-off-by: Jeff Squyres <jeff@squyres.com>