### PR TITLE
logrotate: do not logrotate the ECCMQTT logfile

### DIFF
--- a/media/linux/etc/logrotate.d/epiphany.conf
+++ b/media/linux/etc/logrotate.d/epiphany.conf
@@ -19,12 +19,6 @@
 # These are technically running on the Windows side, but we're using
 # Linux rotate to police up the logfiles.
 
-/home/coeadmin/git/epiphany/media/windows/ECC-MQTT-IoT/ECCMQTTIoT.log {
-    compress
-    size 10M
-    rotate 50
-}
-
 /home/coeadmin/git/epiphany/media/windows/ECC-Ecobee/ECCEcobee.log {
     compress
     size 10M


### PR DESCRIPTION
The ECC MQTT Listener Python script runs in Windows, and the
logrotater runs in Linux.  Weird Things happen when you have a Linux
process rename/edit/delete a file that is open in Windows and is
supposed to be locked by the Windows filesystem.

This is different for the MQTT Listener (vs. our other Python codes)
because the MQTT Listener is running (and logging) 24/7, whereas the
other ECC Python scripts run, log, and then complete/exit.  In the
non-24/7 scenarios, if the logrotater comes in an
moved/renames/compresses the logfile, the next time the Python script
runs, it will just create a new logfile of the same name.  In the 24/7
case, if the logfile is moved/deleted while an active Windows Python process
is still writing to it, the Windows Python process will be unable to
log new entries to that file.

Part of the solution is cedfa8091d973fe422488af892971e2a751a5cc9.  The
other part is to not have the Linux logrotater rotate Windows-based logfiles.

Signed-off-by: Jeff Squyres <jeff@squyres.com>