### PR TITLE
stewardship-2021: fix CSV uploads

### DIFF
--- a/pds-queries/2021-stewardship/nightly-reports.py
+++ b/pds-queries/2021-stewardship/nightly-reports.py
@@ -101,7 +101,7 @@ def upload_to_gsheet(google, folder_id, filename, fieldnames, csv_rows, remove_c
             'supportsTeamDrives' : True,
             }
         media = MediaFileUpload(csv_filename,
-                                mimetype=Google.mime_types['sheet'],
+                                mimetype=Google.mime_types['csv'],
                                 resumable=True)
         file = google.files().create(body=metadata,
                                      media_body=media,


### PR DESCRIPTION
It is important to identify the MediaUpload as a text/csv (because
that's what it is), and then identify the target Google file as a
Gsheet (so that Google will convert from the CSV to a Sheet).

Signed-off-by: Jeff Squyres <jeff@squyres.com>