### PR TITLE
calendar-reservations: send email replies

### DIFF
--- a/media/windows/calendar-reservations/calendar-reservations.py
+++ b/media/windows/calendar-reservations/calendar-reservations.py
@@ -141,6 +141,7 @@ def respond_to_events(events, service, calendar, log):
         if not args.dry_run:
             service.events().patch(
                 calendarId = calendar['id'],
+                sendUpdates = "all",
                 eventId = id,
                 body = response_body,
             ).execute()


### PR DESCRIPTION
When the bot accepts or declines a calendar reservation, be sure to
send an email back to the event owner letting them know.

Signed-off-by: Jeff Squyres <jeff@squyres.com>

FYI @toQhom I added in the "send updates" functionality we talked about on the phone.