### PR TITLE
python: update SMTP_SSL usage

### DIFF
--- a/media/linux/pds-sqlite3-queries/sync-google-group.py
+++ b/media/linux/pds-sqlite3-queries/sync-google-group.py
@@ -112,7 +112,8 @@ def send_mail(to, subject, message_body, html=False, log=None):
     if log:
         log.info('Sending email to {to}, subject "{subject}"'
                  .format(to=to, subject=subject))
-    with smtplib.SMTP_SSL(host=smtp_server) as smtp:
+    with smtplib.SMTP_SSL(host=smtp_server,
+                          local_hostname='epiphanycatholicchurch.org') as smtp:
         if args.debug:
             smtp.set_debuglevel(2)
 

--- a/media/windows/ECC-MQTT-IoT/ECC_MQTT_IoT_SQLite.py
+++ b/media/windows/ECC-MQTT-IoT/ECC_MQTT_IoT_SQLite.py
@@ -963,7 +963,8 @@ def send_mail(mail_origin,
     mail_time_str = mail_time_str + " -" + f'{(time.timezone / 3600):02.0f}00'
 
     try:
-        server = smtplib.SMTP_SSL('smtp.gmail.com', 465)
+        server = smtplib.SMTP_SSL('smtp.gmail.com', 465,
+                                  local_hostname='epiphanycatholicchurch.org')
         # use the following for ECC...
         # server = smtplib.SMTP_SSL('smtp-relay.gmail.com', 465)
     except smtplib.SMTPException as e:

--- a/media/windows/copy-mp3s-to-google-drive/find-and-copy.py
+++ b/media/windows/copy-mp3s-to-google-drive/find-and-copy.py
@@ -166,7 +166,8 @@ def send_mail(subject, message_body, html=False):
 
     log.info('Sending email to {0}, subject "{1}"'
                  .format(smtp_to, subject))
-    with smtplib.SMTP_SSL(host=smtp_server) as smtp:
+    with smtplib.SMTP_SSL(host=smtp_server,
+                          local_hostname='epiphanycatholicchurch.org') as smtp:
         if args.debug:
             smtp.set_debuglevel(2)
 

--- a/media/windows/email-patch-tuesday/patch-tuesday.py
+++ b/media/windows/email-patch-tuesday/patch-tuesday.py
@@ -66,7 +66,8 @@ Myrador</p>'''
 
 #------------------------------------------------------------------
 
-with smtplib.SMTP_SSL(host=smtp_server) as smtp:
+with smtplib.SMTP_SSL(host=smtp_server,
+                      local_hostname='epiphanycatholicchurch.org') as smtp:
     msg = EmailMessage()
     msg.set_content(body)
 

--- a/media/windows/email-timecard-twice-month/email-timecard.py
+++ b/media/windows/email-timecard-twice-month/email-timecard.py
@@ -54,7 +54,8 @@ Teddy</p>'''
 
 #------------------------------------------------------------------
 
-with smtplib.SMTP_SSL(host=smtp_server) as smtp:
+with smtplib.SMTP_SSL(host=smtp_server,
+                      local_hostname='epiphanycatholicchurch.org') as smtp:
     msg = EmailMessage()
     msg.set_content(body)
 

--- a/pds-queries/2020-spring-census/make-and-send-emails.py
+++ b/pds-queries/2020-spring-census/make-and-send-emails.py
@@ -234,7 +234,8 @@ def send_family_email(message_body, to_addresses,
         log.info("NOT SENDING EMAIL (--do-not-send)")
     else:
         try:
-            with smtplib.SMTP_SSL(host=smtp_server) as smtp:
+            with smtplib.SMTP_SSL(host=smtp_server,
+                                  local_hostname='epiphanycatholicchurch.org') as smtp:
                 msg = EmailMessage()
                 msg['Subject'] = smtp_subject
                 msg['From'] = smtp_from

--- a/pds-queries/2021-stewardship/make-and-send-emails.py
+++ b/pds-queries/2021-stewardship/make-and-send-emails.py
@@ -275,7 +275,8 @@ def _send_family_emails(message_body, families, submissions,
         smtp_username, smtp_password = line.split(':')
 
     # Open just one connection to the SMTP server
-    with smtplib.SMTP_SSL(host=smtp_server) as smtp:
+    with smtplib.SMTP_SSL(host=smtp_server,
+                          local_hostname='api.epiphanycatholicchurch.org') as smtp:
         # Login; we can't rely on being IP whitelisted.
         try:
             smtp.login(smtp_username, smtp_password)

--- a/pds-queries/2021-stewardship/nightly-reports.py
+++ b/pds-queries/2021-stewardship/nightly-reports.py
@@ -257,7 +257,8 @@ def comments_report(args, google, start, end, time_period, jotform_data, log):
     try:
         log.info('Sending "{subject}" email to {to}'
                  .format(subject=subject, to=to))
-        with smtplib.SMTP_SSL(host=smtp_server) as smtp:
+        with smtplib.SMTP_SSL(host=smtp_server,
+                              local_hostname='epiphanycatholicchurch.org') as smtp:
             msg = EmailMessage()
             msg['Subject'] = subject
             msg['From'] = smtp_from
@@ -522,7 +523,8 @@ def statistics_report(args, end, pds_members, pds_families, jotform, log):
     try:
         log.info('Sending "{subject}" email to {to}'
                  .format(subject=subject, to=to))
-        with smtplib.SMTP_SSL(host=smtp_server) as smtp:
+        with smtplib.SMTP_SSL(host=smtp_server,
+                              local_hostname='epiphanycatholicchurch.org') as smtp:
             msg = EmailMessage()
             msg['Subject'] = subject
             msg['From'] = smtp_from
@@ -667,7 +669,8 @@ def family_pledge_csv_report(args, google, start, end, time_period, pds_families
     try:
         log.info('Sending "{subject}" email to {to}'
                  .format(subject=subject, to=to))
-        with smtplib.SMTP_SSL(host=smtp_server) as smtp:
+        with smtplib.SMTP_SSL(host=smtp_server,
+                              local_hostname='epiphanycatholicchurch.org') as smtp:
 
             # This assumes that the file has a single line in the format of username:password.
             with open(args.smtp_auth_file) as f:
@@ -1007,7 +1010,8 @@ def old_stuff():
     try:
         log.info('Sending "{subject}" email to {to}'
               .format(subject=subject, to=to))
-        with smtplib.SMTP_SSL(host=smtp_server) as smtp:
+        with smtplib.SMTP_SSL(host=smtp_server,
+                              local_hostname='epiphanycatholicchurch.org') as smtp:
             msg = EmailMessage()
             msg['Subject'] = subject
             msg['From'] = smtp_from
@@ -1112,7 +1116,8 @@ The same spreadsheet <a href="{url}">is also available as a Google Sheet</a>.</p
     try:
         log.info('Sending "{subject}" email to {to}'
               .format(subject=subject, to=to))
-        with smtplib.SMTP_SSL(host=smtp_server) as smtp:
+        with smtplib.SMTP_SSL(host=smtp_server,
+                              local_hostname='epiphanycatholicchurch.org') as smtp:
             msg = EmailMessage()
             msg['Subject'] = subject
             msg['From'] = smtp_from


### PR DESCRIPTION
Specify that our local hostname is "epiphanycatholicchurch.org" so
that we never "ehlo" with 127.0.0.1 if we're on a host with no
internet IP address that has no reverse hostname available (because
Google will immediately disconnect if you "ehlo 127.0.0.1").

Signed-off-by: Jeff Squyres <jeff@squyres.com>