### PR TITLE
eStewardship: protect FDFundTotal

### DIFF
--- a/pds-queries/2021-stewardship/make-and-send-emails.py
+++ b/pds-queries/2021-stewardship/make-and-send-emails.py
@@ -103,7 +103,7 @@ def calculate_family_values(family, year, log=None):
     pledged = 0
     for fund in funds.values():
         fund_rate = fund['fund_rate']
-        if fund_rate:
+        if fund_rate and fund_rate['FDTotal']:
             pledged += int(fund_rate['FDTotal'])
 
     contributed = 0


### PR DESCRIPTION
You can apparently have a fund rate but no total (just discovered this
with a Family who was a non-parishioner for several years, but was
literally just switched to parishioner status), so protect for that
case.

Signed-off-by: Jeff Squyres <jeff@squyres.com>