### PR TITLE
media/linux/run.sh: increase runner timeout

### DIFF
--- a/media/linux/run.sh
+++ b/media/linux/run.sh
@@ -12,9 +12,12 @@ set +ux
 . ./py38/bin/activate
 set -ux
 
+# Set timeout for 14.5 minutes because periodically Google APIs
+# take a long time for no apparent reason
 $TOP/slack/runner.py \
     --slack-token-filename /home/coeadmin/slack-token.txt \
     --logfile runner-log.txt \
+    --child-timeout 900 \
     --verbose \
     --comment "Linux cron run-all automation" \
     -- \


### PR DESCRIPTION
Sometimes Google API calls take *minutes* for no apparent reason.
Rather than fight it, just let the timeout be longer -- it won't cause
any harm, because the next iteration of the Linux python automation will be blocked
from executing by the lockfile, so it doesn't matter if this one takes
a while to run.

Signed-off-by: Jeff Squyres <jeff@squyres.com>