### PR TITLE
sync-google: remove Visual Faith group

### DIFF
--- a/media/linux/pds-sqlite3-queries/sync-google-group.py
+++ b/media/linux/pds-sqlite3-queries/sync-google-group.py
@@ -314,11 +314,6 @@ def get_synchronizations():
             'ggroup'     : f'adult-formation-working-group{ecc}',
             'notify'     : f'lisa{ecc},pds-google-sync{ecc}',
         },
-        {
-            'ministries' : [ '813-Visual Faith Group' ],
-            'ggroup'     : f'visual-faith{ecc}',
-            'notify'     : f'lisa{ecc},pds-google-sync{ecc}',
-        },
 
         #############################
 


### PR DESCRIPTION
This project is now over, and the corresponding Google Group has been
deleted.

Signed-off-by: Jeff Squyres <jeff@squyres.com>