### PR TITLE
Ecobee: update urllib to 1.26.6

### DIFF
--- a/media/windows/ECC-Ecobee/requirements.txt
+++ b/media/windows/ECC-Ecobee/requirements.txt
@@ -1,6 +1,6 @@
 pyecobee==1.3.11
 pytz==2020.4
 pythonping==1.0.8
-urllib3==1.24.3
+urllib3==1.26.6
 certifi==2019.6.16
 dnspython==2.1.0


### PR DESCRIPTION
Per Github Dependabot alert, update our urllib3 library version to
1.26.6.  Dependabot actually suggested we update to 1.26.5, but that
seemed to cause some problems.  Keith verified that 1.26.6 was good to
go, so we're just skipping 1.26.5 and going straight to 1.26.6.

Signed-off-by: Jeff Squyres <jeff@squyres.com>