### PR TITLE
print-keywords.py: new utility

### DIFF
--- a/pds-queries/utilities/print-keywords.py
+++ b/pds-queries/utilities/print-keywords.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+# This script is really just for debugging / reference.  It didn't
+# play a part in the sending of emails, etc.  It was edited and run on
+# demand just as a help for writing / debugging the other scripts.
+
+import sys
+import os
+
+# We assume that there is a "ecc-python-modules" sym link in this directory that points to the directory with ECC.py and friends.
+moddir = os.path.join(os.getcwd(), 'ecc-python-modules')
+if not os.path.exists(moddir):
+    print("ERROR: Could not find the ecc-python-modules directory.")
+    print("ERROR: Please make a ecc-python-modules sym link and run again.")
+    exit(1)
+
+sys.path.insert(0, moddir)
+
+import ECC
+import PDSChurch
+
+from pprint import pprint
+from pprint import pformat
+
+##############################################################################
+
+def print_keywords(name, entities, sql_keywords):
+    keywords = dict()
+    for sql_keyword in sql_keywords.values():
+        keywords[sql_keyword['Description']] = False
+
+    for entity in entities.values():
+        key = 'keywords'
+        if key not in entity:
+            continue
+
+        for keyword in entity[key]:
+            keywords[keyword] = True
+
+    print(f"{name} keywords:")
+    for name in sorted(keywords):
+        active = keywords[name]
+        print(f"{name} {'(no Members)' if not active else ''}")
+
+def main():
+    log = ECC.setup_logging(debug=False)
+
+    (pds, families,
+     members) = PDSChurch.load_families_and_members(filename='pdschurch.sqlite3',
+                                                    log=log)
+
+    # This gets *all* the keywords -- even keywords which aren't
+    # attached to any Member or Family.
+    sql_data = PDSChurch.get_raw_sql_data();
+
+    print_keywords("Member", members, sql_data['member keywords'])
+    print("")
+    print_keywords("Family", families, sql_data['family keywords'])
+
+main()

--- a/python/PDSChurch.py
+++ b/python/PDSChurch.py
@@ -1055,6 +1055,15 @@ def load_families_and_members(filename=None, pds=None,
     if parishioners_only:
         _delete_non_parishioners(families, members)
 
+    # Save the raw data that we might want to access later (outside
+    # the context of just Members and Families).
+    global _sql_data
+    _sql_data = {
+        'ministries' : ministries,
+        'member keywords' : mem_keyword_types,
+        'family keywords' : fam_keyword_types,
+    }
+
     _link_family_emails(families, emails)
     _link_family_city_states(families, city_states)
     _link_family_statuses(families, fam_status_types)


### PR DESCRIPTION
Small Python utility to print out all PDS keywords (both member
keywords and family keywords), and indicate if there are no
members/families who have that keyword.

Signed-off-by: Jeff Squyres <jeff@squyres.com>