### PR TITLE
ministry-rosters.py: fix typo

### DIFF
--- a/media/linux/pds-sqlite3-queries/create-ministry-rosters.py
+++ b/media/linux/pds-sqlite3-queries/create-ministry-rosters.py
@@ -129,7 +129,7 @@ ministries = [
         "birthday"  : False,
     },
     {
-        "ministry"  : '313A-Communion Ministers: Weekday',
+        "ministry"  : '313A-Communion: Weekday',
         "gsheet_id" : '1ep1HrUf1jWB43e-wnHiayq6gcDImo8Y26OQ2e5b8gdw',
         "birthday"  : False,
     },


### PR DESCRIPTION
Fix typo in name of a ministry.

Signed-off-by: Jeff Squyres <jeff@squyres.com>