### PR TITLE
sync-google-group: update Formation notification email

### DIFF
--- a/media/linux/pds-sqlite3-queries/sync-google-group.py
+++ b/media/linux/pds-sqlite3-queries/sync-google-group.py
@@ -311,22 +311,22 @@ def get_synchronizations():
         {
             'ministries' : [ '800-ChildrenFormationCatechist' ],
             'ggroup'     : f'childrens-formation-catechists{ecc}',
-            'notify'     : f'lisa{ecc},pds-google-sync{ecc}',
+            'notify'     : f'formation{ecc},pds-google-sync{ecc}',
         },
         {
             'ministries' : [ '807-RCIA Team' ],
             'ggroup'     : f'rcia-team{ecc}',
-            'notify'     : f'lisa{ecc},pds-google-sync{ecc}',
+            'notify'     : f'formation{ecc},pds-google-sync{ecc}',
         },
         {
             'ministries' : [ "811-Family&Children's WorkGrp" ],
             'ggroup'     : f'family-and-childrens-working-group{ecc}',
-            'notify'     : f'lisa{ecc},pds-google-sync{ecc}',
+            'notify'     : f'formation{ecc},pds-google-sync{ecc}',
         },
         {
             'ministries' : [ '812-Adult Form. Working Group' ],
             'ggroup'     : f'adult-formation-working-group{ecc}',
-            'notify'     : f'lisa{ecc},pds-google-sync{ecc}',
+            'notify'     : f'formation{ecc},pds-google-sync{ecc}',
         },
 
         #############################


### PR DESCRIPTION
Change all the notification email addresses for the Formation-related
groups to formation@ecc.

Signed-off-by: Jeff Squyres <jeff@squyres.com>