### PR TITLE
sync-google-group: add livestream team

### DIFF
--- a/media/linux/pds-sqlite3-queries/sync-google-group.py
+++ b/media/linux/pds-sqlite3-queries/sync-google-group.py
@@ -332,6 +332,14 @@ def get_synchronizations():
         #############################
 
         {
+            'ministries' : [ 'WG-Livestream Team' ],
+            'ggroup'     : f'livestream-team{ecc}',
+            'notify'     : f'director-communications{ecc},pds-google-sync{ecc}',
+        },
+
+        #############################
+
+        {
             'ministries' : [ 'E-Taize Prayer' ],
             'ggroup'     : f'taizeprayer{ecc}',
             'notify'     : f'director-worship{ecc},pds-google-sync{ecc}',


### PR DESCRIPTION
Effectively revert b32e606ce, but with a new ministry name.  The
"451-Livestream Team" ministry no longer exists (because the
livestream team is not a "ministry") -- that's why b32e606ce removed
the linkage between the 451 ministry and the livestream-team@ecc
Google Group.  But we do still need to track the members of the
Livestream Team in PDS, and we want to have a Google Group for them.
So the "451-Livestream Team" ministry has been renamed to be
"WG-Livestream Team" (WG = "Working Group").

Signed-off-by: Jeff Squyres <jeff@squyres.com>