### PR TITLE
ppc-feedback: compare lower case emails

### DIFF
--- a/media/linux/pds-sqlite3-queries/ppc-feedback-google-group.py
+++ b/media/linux/pds-sqlite3-queries/ppc-feedback-google-group.py
@@ -237,7 +237,7 @@ def download_google_sheet(google, gfile, log):
     csvreader = csv.reader(fakefile)
     for row in csvreader:
         date_str  = row[0]
-        email_str = row[1].strip()
+        email_str = row[1].strip().lower()
 
         # Check to make sure that the date string is actually a date.
         # Skip it if it does not.


### PR DESCRIPTION
Ensure to make the email addresses that are read in from the Google
Sheet to be lower case so that we can reliably compare them to the
Google Group members.

Signed-off-by: Jeff Squyres <jeff@squyres.com>