### PR TITLE
sync-google-group: remove communion-ministers-coordinators@ecc

### DIFF
--- a/media/linux/pds-sqlite3-queries/sync-google-group.py
+++ b/media/linux/pds-sqlite3-queries/sync-google-group.py
@@ -216,11 +216,6 @@ def get_synchronizations():
             'notify'     : f'director-worship{ecc},tonya@cabral.org,pds-google-sync{ecc}',
         },
         {
-            'ministries' : [ '314-Communion Min. Coordinator'],
-            'ggroup'     : f'communion-ministers-coordinators{ecc}',
-            'notify'     : f'director-worship{ecc},tonya@cabral.org,pds-google-sync{ecc}',
-        },
-        {
             'ministries' : [ '315-Funeral Mass Ministry' ],
             'ggroup'     : f'funeral-mass-ministry{ecc}',
             'notify'     : f'director-worship{ecc},pds-google-sync{ecc}',


### PR DESCRIPTION
This group was removed in the 2022 google groups audit (it has
effectively been replaced by the Ministry Scheduler Pro app).

Signed-off-by: Jeff Squyres <jeff@squyres.com>