### PR TITLE
sync-google-groups: update

### DIFF
--- a/media/linux/pds-sqlite3-queries/sync-google-group.py
+++ b/media/linux/pds-sqlite3-queries/sync-google-group.py
@@ -189,7 +189,8 @@ def get_synchronizations():
             'notify'     : f'director-worship{ecc},awsimpson57@gmail.com,pds-google-sync{ecc}',
         },
         {
-            'ministries' : [ '309A-Acolyte Ministry 5:30P',
+            'ministries' : [ '309-Acolytes INTERESTED ONLY',
+                             '309A-Acolyte Ministry 5:30P',
                              '309B-Acolyte Ministry  9:00A',
                              '309C-Acolyte Ministry 11:30A' ],
             'ggroup'     : f'acolytes{ecc}',
@@ -221,7 +222,8 @@ def get_synchronizations():
             'notify'     : f'director-worship{ecc},pds-google-sync{ecc}',
         },
         {
-            'ministries' : [ '316A-Greeters 5:30P',
+            'ministries' : [ '316-Greeters INTERESTED ONLY',
+                             '316A-Greeters 5:30P',
                              '316B-Greeters 9:00A',
                              '316C-Greeters 11:30A' ],
             'ggroup'     : f'greeters{ecc}',


### PR DESCRIPTION
Add top-level ministries for 309, 313, 316, and 318.

As of August 2022, it has been decided that we are removing the
A/B/C/D ministries altogether.  Data has been sent to the parish admin
assistant to update PDS such that all Members who are in the A/B/C/D
sub-ministries are *also* in the no-letter ministries.  This will
allow us to remove the A/B/C/D ministries from PDS altogether.

During this transition, sync the Google Groups to the A/B/C/D
ministries *and* the no-letter ministry.  A future commit will remove
syncing against the A/B/C/D ministries.

Signed-off-by: Jeff Squyres <jeff@squyres.com>