### PR TITLE
linux/ricoh: update requirements.txt

### DIFF
--- a/media/linux/ricoh/requirements.txt
+++ b/media/linux/ricoh/requirements.txt
@@ -1,1 +1,3 @@
 bs4
+pytz
+openpyxl


### PR DESCRIPTION
Add some missing Python packages to the linux/ricoh/requirements.txt file.

Signed-off-by: Jeff Squyres <jeff@squyres.com>