### PR TITLE
sync-google-group: use role email address

### DIFF
--- a/media/linux/pds-sqlite3-queries/sync-google-group.py
+++ b/media/linux/pds-sqlite3-queries/sync-google-group.py
@@ -440,12 +440,12 @@ def get_synchronizations():
         {
             'keywords'   : [ 'YouthMin parent: Jr high' ],
             'ggroup'     : f'youth-ministry-parents-jr-high{ecc}',
-            'notify'     : f'deacontrey{ecc},pds-google-sync{ecc}',
+            'notify'     : f'pastoral-associate-youth{ecc},pds-google-sync{ecc}',
         },
         {
             'keywords'   : [ 'YouthMin parent: Sr high' ],
             'ggroup'     : f'youth-ministry-parents-sr-high{ecc}',
-            'notify'     : f'deacontrey{ecc},pds-google-sync{ecc}',
+            'notify'     : f'pastoral-associate-youth{ecc},pds-google-sync{ecc}',
         },
 
         #############################


### PR DESCRIPTION
Use the Youth role email address instead of an individual email address.

Signed-off-by: Jeff Squyres <jeff@squyres.com>