### PR TITLE
gsheet-driven-google-group.py: fix email wording

### DIFF
--- a/media/linux/pds-sqlite3-queries/gsheet-driven-google-group.py
+++ b/media/linux/pds-sqlite3-queries/gsheet-driven-google-group.py
@@ -188,6 +188,7 @@ Thank you for your time and dedication to Epiphany!"""
 
     if len(to_delete) > 0:
         subject = f"Your {data['name']} email rotation: completed!"
+        addrs   = ','.join(to_delete)
         content = f"""Your rotation to respond to respond to {data['name']} emails has completed.
 
 This means that emails sent to {data['group']} will NO LONGER be forwarded to {addrs}.


### PR DESCRIPTION
A trivial missing computation accidentally sent the wrong wording to the addressees who are being removed from the Google Group.  Add the missing line to properly compute the list of email addresses that is insertted into the email body text indicating who will no longer be receiving the Group emails.