### PR TITLE
create-familiy-lists.py: remove extra rows

### DIFF
--- a/media/linux/pds-sqlite3-queries/create-family-lists.py
+++ b/media/linux/pds-sqlite3-queries/create-family-lists.py
@@ -81,27 +81,6 @@ def write_xlsx(families, keyword_name, name, log):
     last_col = 'I'
 
     row = 1
-    ws.merge_cells(f'A{row}:{last_col}{row}')
-    cell = f'A{row}'
-    ws[cell] = f'Keyword: {keyword_name}'
-    ws[cell].fill = title_fill
-    ws[cell].font = title_font
-
-    row = row + 1
-    ws.merge_cells(f'A{row}:{last_col}{row}')
-    cell = f'A{row}'
-    ws[cell] = f'Last updated: {now}'
-    ws[cell].fill = title_fill
-    ws[cell].font = title_font
-
-    row = row + 1
-    ws.merge_cells(f'A{row}:{last_col}{row}')
-    cell = f'A{row}'
-    ws[cell] = ''
-    ws[cell].fill = title_fill
-    ws[cell].font = title_font
-
-    row = row + 1
     columns = [(f'A{row}', 'Family name', 30),
                (f'B{row}', 'Street 1', 30),
                (f'C{row}', 'Street 2', 30),


### PR DESCRIPTION
It turns out that mail merge functionality doesn't like it when there's more than 1 header row.  So ditch all the extra header rows in the family lists google sheet.