### PR TITLE
Add a python module to requirements.txt

### DIFF
--- a/media/linux/google-group-audit/requirements.txt
+++ b/media/linux/google-group-audit/requirements.txt
@@ -1,4 +1,5 @@
 pytz
+httplib2
 google-api-python-client
 openpyxl
 oauth2client


### PR DESCRIPTION
This was accidentally sitting around uncommitted; we now need the httplib2 module for the annual Google Groups audit python script.