### PR TITLE
ParishSoftv2.py: include the last day of a ministry

### DIFF
--- a/python/ParishSoftv2.py
+++ b/python/ParishSoftv2.py
@@ -762,7 +762,7 @@ def _link_member_ministries(members, ministry_type_memberships, log):
                 end = record['endDate']
                 if start is None and end is None:
                     continue
-                if (start and today < start) or (end and today > end):
+                if (start and today < start) or (end and today >= end):
                     continue
 
                 members[mem_duid]['py ministries'][ministry['name']] = {


### PR DESCRIPTION
Should use ">=" instead of ">" date comparison to today to ensure to include the last day of membership in a ministry.