### PR TITLE
ParishSoft: handle Members with multiple email addresses

### DIFF
--- a/media/linux/ps-queries/sync-google-group.py
+++ b/media/linux/ps-queries/sync-google-group.py
@@ -1298,11 +1298,12 @@ def find_matching_members(members, sync, log=None):
 
         # This Member should be in this Google Group.  Yay!
         # But if they don't have an email address, skip them.
-        e = ps_member['emailAddress']
+        e = ps_member['py emailAddresses']
         if e is None:
             continue
 
-        e = e.lower()
+        # Use the first email address
+        e = e[0].lower()
         new_entry = {
             'ps_members' : [ ps_member ],
             'email'      : e,

--- a/python/ParishSoftv2.py
+++ b/python/ParishSoftv2.py
@@ -424,14 +424,12 @@ def _load_families(session, org_id, cache_dir, log):
 
     # A bunch of families have multiple email addresses separated by
     # ";".  Split these into a Python list.
+    # NOTE: Family is "eMailAddress" while the Member is "emailAddress".  Sigh.
     key = 'py eMailAddresses'
     for family in families.values():
-        family[key] = list()
-
         value = family['eMailAddress']
         if value:
-            for address in value.split(';'):
-                family[key].append(address.strip().lower())
+            family[key] = [x.strip().lower() for x in value.split(';')]
 
     return families
 
@@ -511,6 +509,15 @@ def _load_members(session, org_id, cache_dir, log):
     _normalize_dates(elements, ['birthdate', 'dateModified', 'dateOfDeath'])
 
     members = { int(element['memberDUID']) : element for element in elements }
+
+    # Some members have multiple email addresses separated by ";".
+    # Split these into a Python list.
+    # NOTE: Family is "eMailAddress" while the Member is "emailAddress".  Sigh.
+    key = 'py emailAddresses'
+    for member in members.values():
+        value = member['emailAddress']
+        if value:
+            member[key] = [x.strip().lower() for x in value.split(';')]
 
     return members
 
@@ -1056,7 +1063,7 @@ def get_member_public_email(member):
     if not member['family_PublishEMail']:
         return None
 
-    key = 'emailAddress'
+    key = 'py emailAddresses'
     if key in member:
-        return member[key]
+        return member[key][0]
     return None


### PR DESCRIPTION
Handle if a Member's emailAddress field has multiple email addresses separated by ";".

NOTE: The Family email address field is "eMailAddress" while the Member email address field is "emailAddress".  Sigh.