### PR TITLE
ParishSoftv2: protect against empty email field

### DIFF
--- a/python/ParishSoftv2.py
+++ b/python/ParishSoftv2.py
@@ -1211,6 +1211,6 @@ def get_member_public_email(member):
         return None
 
     key = 'py emailAddresses'
-    if key in member:
+    if key in member and member[key]:
         return member[key][0]
     return None


### PR DESCRIPTION
Add one more location where a Member's email address could be empty (i.e., None).