### PR TITLE
Make the Ecobee GitHub Action have the same steps as the final

### DIFF
--- a/.github/workflows/ecobee-google-calendar-control.yaml
+++ b/.github/workflows/ecobee-google-calendar-control.yaml
@@ -18,5 +18,22 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - name: Just put something here
-        run: echo Hello, world!
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.13"
+
+      - name: Install Python dependencies
+        run: |
+          echo Hello, world!
+
+      - name: Save secrets to files
+        run: |
+          echo Hello, world!
+
+      - name: Run the main.py script
+        run: |
+          echo Hello, world!


### PR DESCRIPTION
I'm not entirely sure of GitHub's permissions surrounding existing GitHub Actions.  So let's make a dummy GitHub Action on `main` that has the same workflows and steps as what we're doing on the PR and see if that allows the PR version to run.