### PR TITLE
Allow the Ecobee GitHub Action to run on "pull_request"

### DIFF
--- a/.github/workflows/ecobee-google-calendar-control.yaml
+++ b/.github/workflows/ecobee-google-calendar-control.yaml
@@ -3,7 +3,7 @@ name: Set Ecobee schedules
 on:
   # This is just for debugging on the PR where we first commit the
   # Ecobee schedule code
-  pull_request_target:
+  pull_request:
   schedule:
     - cron: "25,55 9-23 * * *"  # 5:25 AM to 9:55 PM EST
 


### PR DESCRIPTION
"pull_request_target" specifically runs the GitHub Action workflow from the PR base branch, not the PR branch.  That defeats the point of allowing a PR to debug the GitHub Action workflow YAML file.