### PR TITLE
calendar-reservations: put back what GitHub copilot removed

### DIFF
--- a/media/linux/calendar-reservations/calendar-reservations.py
+++ b/media/linux/calendar-reservations/calendar-reservations.py
@@ -285,7 +285,7 @@ def check_for_conflicts(events_to_check, events, calendar, service, log):
                            'reason':f"conflicts with existing event '{event['summary']}' (ID: {event['id']})"
                         })
                         conflicting = True
-                except (KeyError, AttributeError, TypeError) as e:
+                except Exception as e:
                     log.info(f"Event intersection check failed: {e}")
             if not conflicting:
                 log.debug(f"Found an event to accept!  Huzzah! {event['id']}")


### PR DESCRIPTION
Copilot helpfully removed the generic exception checking with some specific exception checking -- which didn't catch the exceptions that happen with ECC's calendar data.  So put the generic exception checking back.