### PR TITLE
Revamp Constant Contact work

### DIFF
--- a/media/linux/ps-queries/cc_sync_config.py
+++ b/media/linux/ps-queries/cc_sync_config.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+# Configuration for sync-ps-to-cc.py: defines the ParishSoft Member
+# Workgroup to Constant Contact List synchronization mappings.
+# Imported by sync-ps-to-cc.py.
+
+SYNCHRONIZATIONS = [
+    {
+        'source ps member wg': 'Daily Gospel Reflections',
+        'target cc list':      'SYNC Daily Gospel Reflections',
+        'notifications':       [
+            'ps-constantcontact-sync@epiphanycatholicchurch.org,'
+            'director-communications@epiphanycatholicchurch.org',
+        ],
+    },
+    {
+        'source ps member wg': 'Parish-wide Email',
+        'target cc list':      'SYNC Parish-wide Email',
+        'notifications':       [
+            'ps-constantcontact-sync@epiphanycatholicchurch.org,'
+            'director-communications@epiphanycatholicchurch.org',
+        ],
+    },
+]

--- a/media/linux/ps-queries/run.sh
+++ b/media/linux/ps-queries/run.sh
@@ -38,16 +38,27 @@ goog_cred_dir=$credential_dir/ps-queries
 
 cc_logfile=$logfile_dir/linux/sync-constant-contact/sync-cc-logfile.txt
 cc_cred_dir=$goog_cred_dir
-./sync-constant-contact.py \
+
+# Run the unsubscribed report once a week on Mondays between 2:00-2:15am
+cc_extra_args=""
+dow=`date '+%u'`
+hour=`date '+%H'`
+minute=`date '+%M'`
+if test $dow -eq 1 -a $hour -eq 2 -a $minute -lt 15; then
+    cc_extra_args="--unsubscribed-report"
+fi
+
+./sync-ps-to-cc.py \
     --ps-api-keyfile $credential_dir/parishsoft-api-key.txt \
     --ps-cache-dir=$git_base/ps-data \
     --cc-client-id $cc_cred_dir/constant-contact-client-id.json \
     --cc-access-token $cc_cred_dir/constant-contact-access-token.json \
     --service-account-json $credential_dir/ecc-emailer-service-account.json \
     --impersonated-user no-reply@epiphanycatholicchurch.org \
-    --notify-email ps-constantcontact-sync@epiphanycatholicchurch.org \
+    --update-names \
     --logfile=$cc_logfile \
-    --debug
+    --debug \
+    $cc_extra_args
 
 ################################################################################
 # Do other things in Google, once a day
@@ -57,9 +68,7 @@ cc_cred_dir=$goog_cred_dir
 
 # We only need to do this once a day, around 2am or so.
 
-h=`date '+%H'`
-m=`date '+%M'`
-if test $h -eq 2 -a $m -lt 15; then
+if test $hour -eq 2 -a $minute -lt 15; then
     roster_logfile=$logfile_dir/linux/ministry-roster/ministry-roster-logfile.txt
     goog_cred_dir=$credential_dir/google-drive-uploader
     ./create-ministry-rosters.py \

--- a/media/linux/ps-queries/sync-constant-contact.py
+++ b/media/linux/ps-queries/sync-constant-contact.py
@@ -34,6 +34,7 @@ sys.path.insert(0, moddir)
 import ECC
 import ParishSoftv2 as ParishSoft
 import ConstantContact as CC
+from ConstantContact import CCAPIError
 
 from oauth2client import tools
 
@@ -738,7 +739,11 @@ def perform_cc_actions(cc_contacts, client_id, access_token,
                 if 'create' in to_do or 'update' in to_do:
                     # We need to update this contact at CC
                     log.info(f"CC action: create or update: {contact[to_do_key]['notifications']}")
-                    CC.create_or_update_contact(contact, client_id, access_token, log)
+                    try:
+                        CC.create_or_update_contact(contact, client_id, access_token, log)
+                    except CCAPIError as e:
+                        log.error(f"Failed to create/update contact: {e}")
+                        exit(1)
 
                 if 'update unsub' in to_do:
                     # The CC.create_contact() function will update a
@@ -756,7 +761,11 @@ def perform_cc_actions(cc_contacts, client_id, access_token,
                     # just created at CC won't fall down into this
                     # block.
                     log.info(f"CC action: update unsub: {contact[to_do_key]['notifications']}")
-                    CC.update_contact_full(contact, client_id, access_token, log)
+                    try:
+                        CC.update_contact_full(contact, client_id, access_token, log)
+                    except CCAPIError as e:
+                        log.error(f"Failed to update contact (unsub): {e}")
+                        exit(1)
 
     # If we did something, send an email about it
     subject = 'Constant Contact synchronization from ParishSoft update'
@@ -1020,28 +1029,40 @@ def main():
         exit(0)
 
     # Download all data from Constant Contact
-    cc_contact_custom_fields = \
-        CC.api_get_all(cc_client_id, cc_access_token,
-                       'contact_custom_fields', 'custom_fields',
-                       log)
+    try:
+        cc_contact_custom_fields = \
+            CC.api_get_all(cc_client_id, cc_access_token,
+                           'contact_custom_fields', 'custom_fields',
+                           log)
+    except CCAPIError as e:
+        log.error(f"Failed to download CC contact custom fields: {e}")
+        exit(1)
     log.debug("Downloaded CC contact custom fields")
     log.debug(pformat(cc_contact_custom_fields))
 
-    cc_lists = \
-        CC.api_get_all(cc_client_id, cc_access_token,
-                       'contact_lists', 'lists',
-                       log)
+    try:
+        cc_lists = \
+            CC.api_get_all(cc_client_id, cc_access_token,
+                           'contact_lists', 'lists',
+                           log)
+    except CCAPIError as e:
+        log.error(f"Failed to download CC lists: {e}")
+        exit(1)
     log.debug("Downloaded CC lists")
     log.debug(pformat(cc_lists))
 
-    cc_contacts = \
-        CC.api_get_all(cc_client_id, cc_access_token,
-                       'contacts', 'contacts',
-                       log,
-                       include='custom_fields,list_memberships,street_addresses',
-                       # Get all contacts -- even those who have been
-                       # deleted.
-                       status='all')
+    try:
+        cc_contacts = \
+            CC.api_get_all(cc_client_id, cc_access_token,
+                           'contacts', 'contacts',
+                           log,
+                           include='custom_fields,list_memberships,street_addresses',
+                           # Get all contacts -- even those who have been
+                           # deleted.
+                           status='all')
+    except CCAPIError as e:
+        log.error(f"Failed to download CC contacts: {e}")
+        exit(1)
     log.debug(f"Downloaded {len(cc_contacts)} CC contacts")
     log.debug(pformat(cc_contacts))
 

--- a/media/linux/ps-queries/sync-ps-to-cc.py
+++ b/media/linux/ps-queries/sync-ps-to-cc.py
@@ -116,6 +116,88 @@ def setup_cli_args():
 
 ####################################################################
 
+def resolve_desired_state(member_workgroups, members, cc_lists, log):
+    desired_emails = []
+
+    for i, sync in enumerate(SYNCHRONIZATIONS):
+        # Resolve PS Member Workgroup
+        wg_name = sync['source ps member wg']
+        found_wg = False
+        for wg in member_workgroups.values():
+            if wg['name'] != wg_name:
+                continue
+
+            found_wg = True
+            emails = set()
+            for item in wg['membership']:
+                if 'py member duid' not in item:
+                    continue
+
+                duid = item['py member duid']
+                member = members[duid]
+                if member['emailAddress']:
+                    emails.add(member['py emailAddresses'][0].lower())
+                else:
+                    log.warning(f"PS Member {member['py friendly name FL']} "
+                                f"(DUID: {member['memberDUID']}) is in WG "
+                                f'"{wg_name}" but has no email address')
+
+            log.info(f'Resolved PS Member Workgroup "{wg_name}": '
+                     f'{len(emails)} members with email')
+            desired_emails.append(emails)
+            break
+
+        if not found_wg:
+            log.error(f'PS Member Workgroup not found: "{wg_name}"')
+            exit(1)
+
+        # Resolve CC List
+        list_name = sync['target cc list']
+        found_list = False
+        for cc_list in cc_lists:
+            if cc_list['name'] == list_name:
+                sync['TARGET CC LIST'] = cc_list
+                log.info(f'Resolved CC List: "{list_name}"')
+                found_list = True
+                break
+
+        if not found_list:
+            log.error(f'CC List not found: "{list_name}"')
+            exit(1)
+
+    return desired_emails
+
+####################################################################
+
+def filter_unsubscribed(cc_contacts, desired_emails, ps_members_by_email,
+                        log):
+    unsubscribed_per_sync = [[] for _ in SYNCHRONIZATIONS]
+
+    for contact in cc_contacts:
+        if contact['email_address'].get('permission_to_send') != 'unsubscribed':
+            continue
+
+        email = contact['email_address']['address']
+        for i in range(len(SYNCHRONIZATIONS)):
+            if email not in desired_emails[i]:
+                continue
+
+            desired_emails[i].discard(email)
+
+            # Collect PS member info for reporting
+            ps_members = ps_members_by_email.get(email, [])
+            names = ', '.join(m['py friendly name FL'] for m in ps_members)
+            duids = ', '.join(str(m['memberDUID']) for m in ps_members)
+
+            unsubscribed_per_sync[i].append((email, names, duids))
+            log.info(f'Filtered unsubscribed contact {email} '
+                     f'from desired set for '
+                     f'"{SYNCHRONIZATIONS[i]["target cc list"]}"')
+
+    return unsubscribed_per_sync
+
+####################################################################
+
 def main():
     args = setup_cli_args()
 
@@ -191,7 +273,15 @@ def main():
         email = member['py emailAddresses'][0].lower()
         ps_members_by_email[email].append(member)
 
-    # Phases 3-7 will be implemented in subsequent tasks
+    # Resolve desired state per sync entry
+    desired_emails = resolve_desired_state(member_workgroups, members,
+                                           cc_lists, log)
+
+    # Filter out CC-unsubscribed emails
+    unsubscribed_per_sync = filter_unsubscribed(cc_contacts, desired_emails,
+                                                ps_members_by_email, log)
+
+    # Phases 4-7 will be implemented in subsequent tasks
 
 if __name__ == '__main__':
     main()

--- a/media/linux/ps-queries/sync-ps-to-cc.py
+++ b/media/linux/ps-queries/sync-ps-to-cc.py
@@ -6,6 +6,7 @@ import argparse
 import logging
 import datetime
 
+from collections import defaultdict
 from pprint import pformat
 
 # We assume that there is a "ecc-python-modules" sym link in this
@@ -149,7 +150,48 @@ def main():
                     impersonated_user=args.impersonated_user,
                     log=log)
 
-    # Phases 2-7 will be implemented in subsequent tasks
+    # Load PS data
+    log.info("Loading ParishSoft data...")
+    families, members, family_workgroups, member_workgroups, ministries = \
+        ParishSoft.load_families_and_members(api_key=args.api_key,
+                                             active_only=True,
+                                             parishioners_only=False,
+                                             cache_dir=args.ps_cache_dir,
+                                             log=log)
+
+    # Download CC data (let CCAPIError propagate on failure)
+    log.info("Downloading Constant Contact lists...")
+    cc_lists = CC.api_get_all(cc_client_id, cc_access_token,
+                              'contact_lists', 'lists', log)
+    log.info("Downloading Constant Contact contacts...")
+    cc_contacts = CC.api_get_all(cc_client_id, cc_access_token,
+                                 'contacts', 'contacts', log,
+                                 include='list_memberships',
+                                 status='all')
+
+    # Normalize CC contact emails to lowercase
+    for contact in cc_contacts:
+        contact['email_address']['address'] = \
+            contact['email_address']['address'].lower()
+
+    # Link CC data structures and correlate with PS Members
+    CC.link_cc_data(cc_contacts, [], cc_lists, log)
+    CC.link_contacts_to_ps_members(cc_contacts, members, log)
+
+    # Build read-only indexes
+    cc_contacts_by_email = {
+        contact['email_address']['address']: contact
+        for contact in cc_contacts
+    }
+
+    ps_members_by_email = defaultdict(list)
+    for member in members.values():
+        if not member['emailAddress']:
+            continue
+        email = member['py emailAddresses'][0].lower()
+        ps_members_by_email[email].append(member)
+
+    # Phases 3-7 will be implemented in subsequent tasks
 
 if __name__ == '__main__':
     main()

--- a/media/linux/ps-queries/sync-ps-to-cc.py
+++ b/media/linux/ps-queries/sync-ps-to-cc.py
@@ -430,96 +430,108 @@ def execute_actions(actions, cc_contacts_by_email, ps_members_by_email,
 
 ####################################################################
 
-def build_notification_email(list_name, list_actions, list_failures,
-                             unsubscribed, cc_contacts_by_email):
+def build_notification_email(list_name, wg_name, list_actions, list_failures,
+                             cc_contacts_by_email, ps_members_by_email):
     esc = html.escape
     now = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
     subject = f'Constant Contact sync update: {list_name}'
 
-    creates = [a for a in list_actions if a['type'] == 'create']
-    subscribes = [a for a in list_actions if a['type'] == 'subscribe']
-    unsubscribes = [a for a in list_actions if a['type'] == 'unsubscribe']
-    name_updates = [a for a in list_actions if a['type'] == 'update_name']
+    email_actions = [a for a in list_actions
+                     if a['type'] not in ('update_name', 'create')]
+    subscribes = [a for a in email_actions if a['type'] == 'subscribe']
+    unsubscribes = [a for a in email_actions if a['type'] == 'unsubscribe']
 
-    tbl = 'border-collapse: collapse; width: 100%; margin-bottom: 20px;'
-    th = ('border: 1px solid #dddddd; padding: 8px; text-align: left; '
-          'background-color: #4472C4; color: white;')
+    tbl = 'border-collapse: collapse; margin-bottom: 20px; width: auto;'
+    th = ('border: 1px solid #dddddd; padding: 8px; text-align: center; '
+          'background-color: #4472C4; color: white; white-space: nowrap;')
 
     def td(row):
         bg = '#f2f2f2' if row % 2 == 0 else '#ffffff'
-        return f'border: 1px solid #dddddd; padding: 8px; background-color: {bg};'
+        return f'border: 1px solid #dddddd; padding: 8px; background-color: {bg}; white-space: nowrap;'
 
     body = (f'<html><body style="font-family: Arial, sans-serif; font-size: 14px;">'
             f'<h2 style="color: #333333;">Constant Contact Sync Update: '
             f'{esc(list_name)}</h2>'
             f'<p style="color: #666666;">Generated: {now}</p>'
+            f'<p><strong>ParishSoft Member Workgroup:</strong> {esc(wg_name)}<br>'
+            f'<strong>Constant Contact List:</strong> {esc(list_name)}</p>'
             f'<h3>Summary</h3><ul>'
-            f'<li>Contacts created: {len(creates)}</li>'
             f'<li>Contacts subscribed: {len(subscribes)}</li>'
             f'<li>Contacts unsubscribed: {len(unsubscribes)}</li>'
-            f'<li>Name updates: {len(name_updates)}</li>'
-            f'<li>Failures: {len(list_failures)}</li>'
+            f'<li>Update failures: {len(list_failures)}</li>'
             f'</ul>')
 
-    # Actions table
-    if list_actions:
+    # Actions table — grouped by action type, sorted by last name
+    if email_actions:
+        def action_sort_key(a):
+            contact = cc_contacts_by_email.get(a['email'], {})
+            return (contact.get('last_name', '').lower(),
+                    contact.get('first_name', '').lower())
+
+        action_order = ['subscribe', 'unsubscribe']
+        grouped = {t: sorted([a for a in email_actions if a['type'] == t],
+                              key=action_sort_key)
+                   for t in action_order}
+
+        ncols = 4
+        sep = (f'<tr><td colspan="{ncols}" style="border: 1px solid #dddddd; '
+               f'padding: 0; height: 6px; background-color: #4472C4;">'
+               f'</td></tr>')
+
         body += (f'<h3>Actions Performed</h3>'
                  f'<table style="{tbl}"><tr>'
                  f'<th style="{th}">Action</th>'
-                 f'<th style="{th}">Email</th>'
-                 f'<th style="{th}">Contact Name</th></tr>')
-        for idx, action in enumerate(list_actions):
-            contact = cc_contacts_by_email.get(action['email'], {})
-            first = contact.get('first_name', '')
-            last = contact.get('last_name', '')
-            name = f'{first} {last}'.strip()
-            body += (f'<tr><td style="{td(idx)}">{esc(action["type"])}</td>'
-                     f'<td style="{td(idx)}">{esc(action["email"])}</td>'
-                     f'<td style="{td(idx)}">{esc(name)}</td></tr>')
+                 f'<th style="{th}">Contact Name(s)</th>'
+                 f'<th style="{th}">ParishSoft Member DUID(s)</th>'
+                 f'<th style="{th}">Email</th></tr>')
+        first_group = True
+        for atype in action_order:
+            if not grouped[atype]:
+                continue
+            if not first_group:
+                body += sep
+            first_group = False
+            for idx, action in enumerate(grouped[atype]):
+                contact = cc_contacts_by_email.get(action['email'], {})
+                first = contact.get('first_name', '')
+                last = contact.get('last_name', '')
+                name = f'{first} {last}'.strip()
+                ps_members = (contact.get('PS MEMBERS')
+                              or ps_members_by_email.get(action['email'], []))
+                duids = ', '.join(str(m['memberDUID']) for m in ps_members)
+                body += (f'<tr><td style="{td(idx)}">{esc(action["type"])}</td>'
+                         f'<td style="{td(idx)}">{esc(name)}</td>'
+                         f'<td style="{td(idx)}">{esc(duids)}</td>'
+                         f'<td style="{td(idx)}">{esc(action["email"])}</td></tr>')
         body += '</table>'
 
-    # Manually unsubscribed contacts
-    if unsubscribed:
-        body += (f'<h3>Manually Unsubscribed Contacts</h3>'
-                 f'<p>These contacts have globally unsubscribed from '
-                 f'Constant Contact but are still in the corresponding '
-                 f'ParishSoft workgroup.</p>'
-                 f'<table style="{tbl}"><tr>'
-                 f'<th style="{th}">Email</th>'
-                 f'<th style="{th}">PS Member Name(s)</th>'
-                 f'<th style="{th}">PS Member DUID(s)</th></tr>')
-        for idx, (email, names, duids) in enumerate(unsubscribed):
-            body += (f'<tr><td style="{td(idx)}">{esc(email)}</td>'
-                     f'<td style="{td(idx)}">{esc(names)}</td>'
-                     f'<td style="{td(idx)}">{esc(duids)}</td></tr>')
-        body += '</table>'
-
-    # Contacts removed from list
-    if unsubscribes:
-        body += (f'<h3>Contacts Removed from List (in ParishSoft)</h3>'
-                 f'<table style="{tbl}"><tr>'
-                 f'<th style="{th}">Email</th>'
-                 f'<th style="{th}">Contact Name</th>'
-                 f'<th style="{th}">Reason</th></tr>')
-        for idx, action in enumerate(unsubscribes):
-            contact = cc_contacts_by_email.get(action['email'], {})
-            first = contact.get('first_name', '')
-            last = contact.get('last_name', '')
-            name = f'{first} {last}'.strip()
-            body += (f'<tr><td style="{td(idx)}">{esc(action["email"])}</td>'
-                     f'<td style="{td(idx)}">{esc(name)}</td>'
-                     f'<td style="{td(idx)}">Not in PS workgroup</td></tr>')
-        body += '</table>'
-
-    # Failed actions
+    # Failed actions — sorted by last name, first name
     if list_failures:
+        def failure_sort_key(f):
+            contact = cc_contacts_by_email.get(f['email'], {})
+            return (contact.get('last_name', '').lower(),
+                    contact.get('first_name', '').lower())
+
+        sorted_failures = sorted(list_failures, key=failure_sort_key)
+
         body += (f'<h3 style="color: #cc0000;">Failed Actions</h3>'
                  f'<table style="{tbl}"><tr>'
+                 f'<th style="{th}">Contact Name(s)</th>'
+                 f'<th style="{th}">ParishSoft Member DUID(s)</th>'
                  f'<th style="{th}">Email</th>'
                  f'<th style="{th}">Action</th>'
-                 f'<th style="{th}">Error</th></tr>')
-        for idx, failure in enumerate(list_failures):
-            body += (f'<tr><td style="{td(idx)}">{esc(failure["email"])}</td>'
+                 f'<th style="{th}">Update error</th></tr>')
+        for idx, failure in enumerate(sorted_failures):
+            contact = cc_contacts_by_email.get(failure['email'], {})
+            first = contact.get('first_name', '')
+            last = contact.get('last_name', '')
+            name = f'{first} {last}'.strip()
+            ps_members = (contact.get('PS MEMBERS')
+                          or ps_members_by_email.get(failure['email'], []))
+            duids = ', '.join(str(m['memberDUID']) for m in ps_members)
+            body += (f'<tr><td style="{td(idx)}">{esc(name)}</td>'
+                     f'<td style="{td(idx)}">{esc(duids)}</td>'
+                     f'<td style="{td(idx)}">{esc(failure["email"])}</td>'
                      f'<td style="{td(idx)}">{esc(failure["action"])}</td>'
                      f'<td style="{td(idx)}">{esc(failure["error"])}</td></tr>')
         body += '</table>'
@@ -535,7 +547,8 @@ def build_notification_email(list_name, list_actions, list_failures,
 ####################################################################
 
 def send_notification_emails(actions, failures, unsubscribed_per_sync,
-                             cc_contacts_by_email, dry_run, no_sync, log):
+                             cc_contacts_by_email, ps_members_by_email,
+                             dry_run, no_sync, log):
     if dry_run or no_sync:
         return
 
@@ -548,8 +561,9 @@ def send_notification_emails(actions, failures, unsubscribed_per_sync,
         list_failures = [f for f in failures if f['email'] in action_emails]
 
         subject, body = build_notification_email(
-            sync['target cc list'], list_actions, list_failures,
-            unsubscribed_per_sync[i], cc_contacts_by_email)
+            sync['target cc list'], sync['source ps member wg'],
+            list_actions, list_failures,
+            cc_contacts_by_email, ps_members_by_email)
 
         for addr_string in sync['notifications']:
             for addr in addr_string.split(','):
@@ -566,13 +580,13 @@ def build_unsubscribed_report_email(list_name, wg_name, unsubscribed):
     now = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
     subject = f'Constant Contact unsubscribed contacts report: {list_name}'
 
-    tbl = 'border-collapse: collapse; width: 100%; margin-bottom: 20px;'
-    th = ('border: 1px solid #dddddd; padding: 8px; text-align: left; '
-          'background-color: #4472C4; color: white;')
+    tbl = 'border-collapse: collapse; margin-bottom: 20px; width: auto;'
+    th = ('border: 1px solid #dddddd; padding: 8px; text-align: center; '
+          'background-color: #4472C4; color: white; white-space: nowrap;')
 
     def td(row):
         bg = '#f2f2f2' if row % 2 == 0 else '#ffffff'
-        return f'border: 1px solid #dddddd; padding: 8px; background-color: {bg};'
+        return f'border: 1px solid #dddddd; padding: 8px; background-color: {bg}; white-space: nowrap;'
 
     body = (f'<html><body style="font-family: Arial, sans-serif; font-size: 14px;">'
             f'<h2 style="color: #333333;">Constant Contact Unsubscribed '
@@ -580,14 +594,24 @@ def build_unsubscribed_report_email(list_name, wg_name, unsubscribed):
             f'<p style="color: #666666;">Generated: {now}</p>'
             f'<p>The following ParishSoft Members are in the '
             f"'{esc(wg_name)}' workgroup but have manually unsubscribed "
-            f'from Constant Contact. They should be removed from the '
+            f'from Constant Contact.</p>'
+            f'<p style="color: #cc0000; font-weight: bold; font-size: 16px;">'
+            f'These ParishSoft Members should be removed from the '
             f"'{esc(wg_name)}' workgroup in ParishSoft.</p>"
             f'<table style="{tbl}"><tr>'
             f'<th style="{th}">PS Member Name(s)</th>'
             f'<th style="{th}">PS Member DUID(s)</th>'
             f'<th style="{th}">Email</th></tr>')
 
-    for idx, (email, names, duids) in enumerate(unsubscribed):
+    def unsub_sort_key(row):
+        parts = row[1].split(',')[0].strip().split()
+        last = parts[-1].lower() if parts else ''
+        first = parts[0].lower() if parts else ''
+        return (last, first)
+
+    sorted_unsub = sorted(unsubscribed, key=unsub_sort_key)
+
+    for idx, (email, names, duids) in enumerate(sorted_unsub):
         body += (f'<tr><td style="{td(idx)}">{esc(names)}</td>'
                  f'<td style="{td(idx)}">{esc(duids)}</td>'
                  f'<td style="{td(idx)}">{esc(email)}</td></tr>')
@@ -748,7 +772,7 @@ def main():
 
     # Send notification emails
     send_notification_emails(actions, failures, unsubscribed_per_sync,
-                             cc_contacts_by_email,
+                             cc_contacts_by_email, ps_members_by_email,
                              args.dry_run, args.no_sync, log)
 
     # Send unsubscribed-contacts report

--- a/media/linux/ps-queries/sync-ps-to-cc.py
+++ b/media/linux/ps-queries/sync-ps-to-cc.py
@@ -721,7 +721,15 @@ def main():
     unsubscribed_per_sync = filter_unsubscribed(cc_contacts, desired_emails,
                                                 ps_members_by_email, log)
 
-    # Compute action list
+    # Compute action list.
+    #
+    # Email-change scenarios (members splitting or merging emails) are
+    # handled naturally by the set-diff architecture:
+    # - Split: the new email appears in emails_needing_contacts and gets
+    #   a create action; the old contact may get an update_name action.
+    # - Merge: one contact now maps to multiple members (name may update);
+    #   the other contact loses its PS members and is logged as a
+    #   deletion candidate.
     actions = []
     actions.extend(compute_create_actions(desired_emails,
                                           cc_contacts_by_email))

--- a/media/linux/ps-queries/sync-ps-to-cc.py
+++ b/media/linux/ps-queries/sync-ps-to-cc.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import html
 import os
 import sys
 import argparse
@@ -429,6 +430,214 @@ def execute_actions(actions, cc_contacts_by_email, ps_members_by_email,
 
 ####################################################################
 
+def build_notification_email(list_name, list_actions, list_failures,
+                             unsubscribed, cc_contacts_by_email):
+    esc = html.escape
+    now = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    subject = f'Constant Contact sync update: {list_name}'
+
+    creates = [a for a in list_actions if a['type'] == 'create']
+    subscribes = [a for a in list_actions if a['type'] == 'subscribe']
+    unsubscribes = [a for a in list_actions if a['type'] == 'unsubscribe']
+    name_updates = [a for a in list_actions if a['type'] == 'update_name']
+
+    tbl = 'border-collapse: collapse; width: 100%; margin-bottom: 20px;'
+    th = ('border: 1px solid #dddddd; padding: 8px; text-align: left; '
+          'background-color: #4472C4; color: white;')
+
+    def td(row):
+        bg = '#f2f2f2' if row % 2 == 0 else '#ffffff'
+        return f'border: 1px solid #dddddd; padding: 8px; background-color: {bg};'
+
+    body = (f'<html><body style="font-family: Arial, sans-serif; font-size: 14px;">'
+            f'<h2 style="color: #333333;">Constant Contact Sync Update: '
+            f'{esc(list_name)}</h2>'
+            f'<p style="color: #666666;">Generated: {now}</p>'
+            f'<h3>Summary</h3><ul>'
+            f'<li>Contacts created: {len(creates)}</li>'
+            f'<li>Contacts subscribed: {len(subscribes)}</li>'
+            f'<li>Contacts unsubscribed: {len(unsubscribes)}</li>'
+            f'<li>Name updates: {len(name_updates)}</li>'
+            f'<li>Failures: {len(list_failures)}</li>'
+            f'</ul>')
+
+    # Actions table
+    if list_actions:
+        body += (f'<h3>Actions Performed</h3>'
+                 f'<table style="{tbl}"><tr>'
+                 f'<th style="{th}">Action</th>'
+                 f'<th style="{th}">Email</th>'
+                 f'<th style="{th}">Contact Name</th></tr>')
+        for idx, action in enumerate(list_actions):
+            contact = cc_contacts_by_email.get(action['email'], {})
+            first = contact.get('first_name', '')
+            last = contact.get('last_name', '')
+            name = f'{first} {last}'.strip()
+            body += (f'<tr><td style="{td(idx)}">{esc(action["type"])}</td>'
+                     f'<td style="{td(idx)}">{esc(action["email"])}</td>'
+                     f'<td style="{td(idx)}">{esc(name)}</td></tr>')
+        body += '</table>'
+
+    # Manually unsubscribed contacts
+    if unsubscribed:
+        body += (f'<h3>Manually Unsubscribed Contacts</h3>'
+                 f'<p>These contacts have globally unsubscribed from '
+                 f'Constant Contact but are still in the corresponding '
+                 f'ParishSoft workgroup.</p>'
+                 f'<table style="{tbl}"><tr>'
+                 f'<th style="{th}">Email</th>'
+                 f'<th style="{th}">PS Member Name(s)</th>'
+                 f'<th style="{th}">PS Member DUID(s)</th></tr>')
+        for idx, (email, names, duids) in enumerate(unsubscribed):
+            body += (f'<tr><td style="{td(idx)}">{esc(email)}</td>'
+                     f'<td style="{td(idx)}">{esc(names)}</td>'
+                     f'<td style="{td(idx)}">{esc(duids)}</td></tr>')
+        body += '</table>'
+
+    # Contacts removed from list
+    if unsubscribes:
+        body += (f'<h3>Contacts Removed from List (in ParishSoft)</h3>'
+                 f'<table style="{tbl}"><tr>'
+                 f'<th style="{th}">Email</th>'
+                 f'<th style="{th}">Contact Name</th>'
+                 f'<th style="{th}">Reason</th></tr>')
+        for idx, action in enumerate(unsubscribes):
+            contact = cc_contacts_by_email.get(action['email'], {})
+            first = contact.get('first_name', '')
+            last = contact.get('last_name', '')
+            name = f'{first} {last}'.strip()
+            body += (f'<tr><td style="{td(idx)}">{esc(action["email"])}</td>'
+                     f'<td style="{td(idx)}">{esc(name)}</td>'
+                     f'<td style="{td(idx)}">Not in PS workgroup</td></tr>')
+        body += '</table>'
+
+    # Failed actions
+    if list_failures:
+        body += (f'<h3 style="color: #cc0000;">Failed Actions</h3>'
+                 f'<table style="{tbl}"><tr>'
+                 f'<th style="{th}">Email</th>'
+                 f'<th style="{th}">Action</th>'
+                 f'<th style="{th}">Error</th></tr>')
+        for idx, failure in enumerate(list_failures):
+            body += (f'<tr><td style="{td(idx)}">{esc(failure["email"])}</td>'
+                     f'<td style="{td(idx)}">{esc(failure["action"])}</td>'
+                     f'<td style="{td(idx)}">{esc(failure["error"])}</td></tr>')
+        body += '</table>'
+
+    body += ('<hr style="border: 1px solid #dddddd; margin-top: 30px;">'
+             '<p style="color: #999999; font-size: 12px;">'
+             'This is an automated message from the ParishSoft to '
+             'Constant Contact synchronization script.</p>'
+             '</body></html>')
+
+    return subject, body
+
+####################################################################
+
+def send_notification_emails(actions, failures, unsubscribed_per_sync,
+                             cc_contacts_by_email, dry_run, no_sync, log):
+    if dry_run or no_sync:
+        return
+
+    for i, sync in enumerate(SYNCHRONIZATIONS):
+        list_actions = [a for a in actions if a['sync_index'] == i]
+        if not list_actions:
+            continue
+
+        action_emails = {a['email'] for a in list_actions}
+        list_failures = [f for f in failures if f['email'] in action_emails]
+
+        subject, body = build_notification_email(
+            sync['target cc list'], list_actions, list_failures,
+            unsubscribed_per_sync[i], cc_contacts_by_email)
+
+        for addr_string in sync['notifications']:
+            for addr in addr_string.split(','):
+                addr = addr.strip()
+                if addr:
+                    ECC.send_email(to_addr=addr, subject=subject,
+                                   body=body, content_type='text/html',
+                                   log=log)
+
+####################################################################
+
+def build_unsubscribed_report_email(list_name, wg_name, unsubscribed):
+    esc = html.escape
+    now = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    subject = f'Constant Contact unsubscribed contacts report: {list_name}'
+
+    tbl = 'border-collapse: collapse; width: 100%; margin-bottom: 20px;'
+    th = ('border: 1px solid #dddddd; padding: 8px; text-align: left; '
+          'background-color: #4472C4; color: white;')
+
+    def td(row):
+        bg = '#f2f2f2' if row % 2 == 0 else '#ffffff'
+        return f'border: 1px solid #dddddd; padding: 8px; background-color: {bg};'
+
+    body = (f'<html><body style="font-family: Arial, sans-serif; font-size: 14px;">'
+            f'<h2 style="color: #333333;">Constant Contact Unsubscribed '
+            f'Contacts Report: {esc(list_name)}</h2>'
+            f'<p style="color: #666666;">Generated: {now}</p>'
+            f'<p>The following ParishSoft Members are in the '
+            f"'{esc(wg_name)}' workgroup but have manually unsubscribed "
+            f'from Constant Contact. They should be removed from the '
+            f"'{esc(wg_name)}' workgroup in ParishSoft.</p>"
+            f'<table style="{tbl}"><tr>'
+            f'<th style="{th}">PS Member Name(s)</th>'
+            f'<th style="{th}">PS Member DUID(s)</th>'
+            f'<th style="{th}">Email</th></tr>')
+
+    for idx, (email, names, duids) in enumerate(unsubscribed):
+        body += (f'<tr><td style="{td(idx)}">{esc(names)}</td>'
+                 f'<td style="{td(idx)}">{esc(duids)}</td>'
+                 f'<td style="{td(idx)}">{esc(email)}</td></tr>')
+
+    body += ('</table>'
+             '<hr style="border: 1px solid #dddddd; margin-top: 30px;">'
+             '<p style="color: #999999; font-size: 12px;">'
+             'This is an automated message from the ParishSoft to '
+             'Constant Contact synchronization script.</p>'
+             '</body></html>')
+
+    return subject, body
+
+####################################################################
+
+def send_unsubscribed_report(unsubscribed_per_sync, dry_run,
+                             unsubscribed_report, log):
+    if not unsubscribed_report:
+        return
+
+    for i, sync in enumerate(SYNCHRONIZATIONS):
+        if not unsubscribed_per_sync[i]:
+            continue
+
+        subject, body = build_unsubscribed_report_email(
+            sync['target cc list'],
+            sync['source ps member wg'],
+            unsubscribed_per_sync[i])
+
+        if dry_run:
+            log.warning(f'--unsubscribed-report requested but --dry-run '
+                        f'is active; not sending email for '
+                        f'"{sync["target cc list"]}"')
+            log.info(f'Unsubscribed report subject: {subject}')
+            log.info(f'CC List: {sync["target cc list"]}')
+            log.info(f'PS Workgroup: {sync["source ps member wg"]}')
+            for email, names, duids in unsubscribed_per_sync[i]:
+                log.info(f'  {names} (DUID: {duids}): {email}')
+            continue
+
+        for addr_string in sync['notifications']:
+            for addr in addr_string.split(','):
+                addr = addr.strip()
+                if addr:
+                    ECC.send_email(to_addr=addr, subject=subject,
+                                   body=body, content_type='text/html',
+                                   log=log)
+
+####################################################################
+
 def main():
     args = setup_cli_args()
 
@@ -529,7 +738,14 @@ def main():
                                cc_client_id, cc_access_token,
                                args.dry_run, args.no_sync, log)
 
-    # Phases 6-7 will be implemented in subsequent tasks
+    # Send notification emails
+    send_notification_emails(actions, failures, unsubscribed_per_sync,
+                             cc_contacts_by_email,
+                             args.dry_run, args.no_sync, log)
+
+    # Send unsubscribed-contacts report
+    send_unsubscribed_report(unsubscribed_per_sync,
+                             args.dry_run, args.unsubscribed_report, log)
 
 if __name__ == '__main__':
     main()

--- a/media/linux/ps-queries/sync-ps-to-cc.py
+++ b/media/linux/ps-queries/sync-ps-to-cc.py
@@ -198,6 +198,135 @@ def filter_unsubscribed(cc_contacts, desired_emails, ps_members_by_email,
 
 ####################################################################
 
+def compute_create_actions(desired_emails, cc_contacts_by_email):
+    actions = []
+
+    all_desired = set()
+    for emails in desired_emails:
+        all_desired |= emails
+
+    emails_needing_contacts = all_desired - set(cc_contacts_by_email.keys())
+
+    for email in sorted(emails_needing_contacts):
+        # Find the first sync entry that wants this email
+        sync_index = next(i for i, emails in enumerate(desired_emails)
+                         if email in emails)
+        actions.append({
+            'type':       'create',
+            'email':      email,
+            'list_name':  None,
+            'list_uuid':  None,
+            'detail':     f'Create contact for {email}',
+            'sync_index': sync_index,
+        })
+
+    return actions
+
+####################################################################
+
+def compute_subscribe_unsubscribe_actions(desired_emails):
+    actions = []
+
+    for i, sync in enumerate(SYNCHRONIZATIONS):
+        cc_list = sync['TARGET CC LIST']
+        list_uuid = cc_list['list_id']
+        list_name = sync['target cc list']
+
+        current_emails = set(cc_list['CONTACTS'].keys())
+        to_subscribe = desired_emails[i] - current_emails
+        to_unsubscribe = current_emails - desired_emails[i]
+
+        for email in sorted(to_subscribe):
+            actions.append({
+                'type':       'subscribe',
+                'email':      email,
+                'list_name':  list_name,
+                'list_uuid':  list_uuid,
+                'detail':     f'Subscribe {email} to {list_name}',
+                'sync_index': i,
+            })
+
+        for email in sorted(to_unsubscribe):
+            actions.append({
+                'type':       'unsubscribe',
+                'email':      email,
+                'list_name':  list_name,
+                'list_uuid':  list_uuid,
+                'detail':     f'Unsubscribe {email} from {list_name}',
+                'sync_index': i,
+            })
+
+    return actions
+
+####################################################################
+
+def detect_name_mismatches(cc_contacts_by_email, update_names, log):
+    actions = []
+
+    for email, contact in cc_contacts_by_email.items():
+        if not contact.get('PS MEMBERS'):
+            continue
+
+        expected_first, expected_last = \
+            ParishSoft.salutation_for_members(contact['PS MEMBERS'])
+        # CC rejects periods in names
+        expected_first = expected_first.replace('.', '')
+
+        old_first = contact.get('first_name', '')
+        old_last = contact.get('last_name', '')
+
+        if expected_first == old_first and expected_last == old_last:
+            continue
+
+        log.info(f'Name mismatch for {email}: '
+                 f'CC has "{old_first} {old_last}", '
+                 f'PS expects "{expected_first} {expected_last}"')
+
+        if update_names:
+            actions.append({
+                'type':       'update_name',
+                'email':      email,
+                'list_name':  None,
+                'list_uuid':  None,
+                'detail':     f'Update name for {email}: '
+                              f'"{old_first} {old_last}" -> '
+                              f'"{expected_first} {expected_last}"',
+                'sync_index': None,
+                'new_first':  expected_first,
+                'new_last':   expected_last,
+                'old_first':  old_first,
+                'old_last':   old_last,
+            })
+
+    return actions
+
+####################################################################
+
+def log_deletion_candidates(cc_contacts_by_email, actions, log):
+    # Count unsubscribe actions per email
+    unsub_counts = defaultdict(int)
+    for action in actions:
+        if action['type'] == 'unsubscribe':
+            unsub_counts[action['email']] += 1
+
+    for email, contact in cc_contacts_by_email.items():
+        first = contact.get('first_name', '')
+        last = contact.get('last_name', '')
+
+        # No PS Members linked
+        if not contact.get('PS MEMBERS'):
+            log.info(f'Deletion candidate (no PS Members): '
+                     f'{email} ({first} {last})')
+
+        # Would have zero list memberships after sync
+        current_count = len(contact.get('list_memberships', []))
+        post_sync_count = current_count - unsub_counts.get(email, 0)
+        if post_sync_count == 0:
+            log.info(f'Deletion candidate (no lists after sync): '
+                     f'{email} ({first} {last})')
+
+####################################################################
+
 def main():
     args = setup_cli_args()
 
@@ -281,7 +410,18 @@ def main():
     unsubscribed_per_sync = filter_unsubscribed(cc_contacts, desired_emails,
                                                 ps_members_by_email, log)
 
-    # Phases 4-7 will be implemented in subsequent tasks
+    # Compute action list
+    actions = []
+    actions.extend(compute_create_actions(desired_emails,
+                                          cc_contacts_by_email))
+    actions.extend(compute_subscribe_unsubscribe_actions(desired_emails))
+    actions.extend(detect_name_mismatches(cc_contacts_by_email,
+                                          args.update_names, log))
+
+    # Log deletion candidates (not added to action list)
+    log_deletion_candidates(cc_contacts_by_email, actions, log)
+
+    # Phases 5-7 will be implemented in subsequent tasks
 
 if __name__ == '__main__':
     main()

--- a/media/linux/ps-queries/sync-ps-to-cc.py
+++ b/media/linux/ps-queries/sync-ps-to-cc.py
@@ -327,6 +327,108 @@ def log_deletion_candidates(cc_contacts_by_email, actions, log):
 
 ####################################################################
 
+def execute_actions(actions, cc_contacts_by_email, ps_members_by_email,
+                    cc_client_id, cc_access_token, dry_run, no_sync, log):
+    failures = []
+
+    # Group actions by email
+    actions_by_email = defaultdict(list)
+    for action in actions:
+        actions_by_email[action['email']].append(action)
+
+    for email in sorted(actions_by_email.keys()):
+        email_actions = actions_by_email[email]
+
+        creates = [a for a in email_actions if a['type'] == 'create']
+        subscribes = [a for a in email_actions if a['type'] == 'subscribe']
+        unsubscribes = [a for a in email_actions if a['type'] == 'unsubscribe']
+        name_updates = [a for a in email_actions if a['type'] == 'update_name']
+
+        # Build POST dict (create or subscribe via sign_up_form endpoint)
+        post_dict = None
+        if creates or subscribes:
+            if creates:
+                post_dict = CC.create_contact_dict(
+                    email, ps_members_by_email[email], log)
+                post_dict['list_memberships'] = [
+                    a['list_uuid'] for a in subscribes
+                ]
+            else:
+                existing = cc_contacts_by_email[email]
+                post_dict = {
+                    'email_address': {'address': email},
+                    'first_name': existing.get('first_name', ''),
+                    'last_name': existing.get('last_name', ''),
+                    'list_memberships': [
+                        a['list_uuid'] for a in subscribes
+                    ],
+                }
+
+        # Build PUT dict (unsubscribe or name update)
+        put_dict = None
+        if unsubscribes or name_updates:
+            existing = cc_contacts_by_email[email]
+            put_dict = {
+                'contact_id': existing['contact_id'],
+                'email_address': existing['email_address'],
+                'first_name': existing.get('first_name', ''),
+                'last_name': existing.get('last_name', ''),
+                'list_memberships': list(existing.get('list_memberships', [])),
+            }
+
+            for a in unsubscribes:
+                if a['list_uuid'] in put_dict['list_memberships']:
+                    put_dict['list_memberships'].remove(a['list_uuid'])
+
+            if name_updates:
+                nu = name_updates[-1]
+                put_dict['first_name'] = nu['new_first']
+                put_dict['last_name'] = nu['new_last']
+
+        # If both POST and PUT exist, merge newly subscribed lists into
+        # the PUT payload so the PUT (which replaces full memberships)
+        # does not clobber what the POST just added.
+        if post_dict and put_dict:
+            for uuid in post_dict.get('list_memberships', []):
+                if uuid not in put_dict['list_memberships']:
+                    put_dict['list_memberships'].append(uuid)
+
+        # Execute or log
+        if dry_run or no_sync:
+            for a in email_actions:
+                log.info(f"Dry-run/no-sync: {a['detail']}")
+            continue
+
+        if post_dict:
+            try:
+                CC.create_or_update_contact(post_dict, cc_client_id,
+                                            cc_access_token, log)
+            except CCAPIError as e:
+                log.error(f"POST failed for {email}: "
+                          f"HTTP {e.status_code}: {e.response_text}")
+                failures.append({
+                    'email': email,
+                    'action': 'POST',
+                    'error': str(e),
+                })
+
+        if put_dict:
+            try:
+                CC.update_contact_full(put_dict, cc_client_id,
+                                       cc_access_token, log)
+            except CCAPIError as e:
+                log.error(f"PUT failed for {email}: "
+                          f"HTTP {e.status_code}: {e.response_text}")
+                failures.append({
+                    'email': email,
+                    'action': 'PUT',
+                    'error': str(e),
+                })
+
+    return failures
+
+####################################################################
+
 def main():
     args = setup_cli_args()
 
@@ -421,7 +523,13 @@ def main():
     # Log deletion candidates (not added to action list)
     log_deletion_candidates(cc_contacts_by_email, actions, log)
 
-    # Phases 5-7 will be implemented in subsequent tasks
+    # Execute action list
+    failures = execute_actions(actions, cc_contacts_by_email,
+                               ps_members_by_email,
+                               cc_client_id, cc_access_token,
+                               args.dry_run, args.no_sync, log)
+
+    # Phases 6-7 will be implemented in subsequent tasks
 
 if __name__ == '__main__':
     main()

--- a/media/linux/ps-queries/sync-ps-to-cc.py
+++ b/media/linux/ps-queries/sync-ps-to-cc.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import argparse
+import logging
+import datetime
+
+from pprint import pformat
+
+# We assume that there is a "ecc-python-modules" sym link in this
+# directory that points to the directory with ECC.py and friends.
+moddir = '../../../python'
+if not os.path.exists(moddir):
+    print("ERROR: Could not find the ecc-python-modules directory.")
+    print("ERROR: Please make a ecc-python-modules sym link and run again.")
+    exit(1)
+# On MS Windows, git checks out sym links as a file with a single-line
+# string containing the name of the file that the sym link points to.
+if os.path.isfile(moddir):
+    with open(moddir) as fp:
+        dir = fp.readlines()
+    moddir = os.path.join(os.getcwd(), dir[0])
+
+sys.path.insert(0, moddir)
+
+import ECC
+import ParishSoftv2 as ParishSoft
+import ConstantContact as CC
+from ConstantContact import CCAPIError
+from cc_sync_config import SYNCHRONIZATIONS
+
+####################################################################
+
+def setup_cli_args():
+    parser = argparse.ArgumentParser(
+        description='Synchronize ParishSoft Member Workgroups to Constant Contact Lists')
+
+    parser.add_argument('--ps-api-keyfile',
+                        help='File containing the ParishSoft API key')
+
+    parser.add_argument('--cc-client-id',
+                        default='constant-contact-client-id.json',
+                        help='File containing the Constant Contact Client ID')
+
+    parser.add_argument('--cc-access-token',
+                        default='constant-contact-access-token.json',
+                        help='File containing the Constant Contact access token')
+
+    parser.add_argument('--service-account-json',
+                        default='ecc-emailer-service-account.json',
+                        help='File containing the Google service account JSON key')
+
+    parser.add_argument('--impersonated-user',
+                        default='no-reply@epiphanycatholicchurch.org',
+                        help='Google Workspace user to impersonate via DWD')
+
+    parser.add_argument('--ps-cache-dir',
+                        default='datacache',
+                        help='Directory to cache ParishSoft data')
+
+    parser.add_argument('--cc-auth-only',
+                        default=False,
+                        action='store_true',
+                        help='Only authenticate to Constant Contact, then exit')
+
+    parser.add_argument('--update-names',
+                        default=False,
+                        action='store_true',
+                        help='Update CC Contact names from PS data when they differ')
+
+    parser.add_argument('--unsubscribed-report',
+                        default=False,
+                        action='store_true',
+                        help='Generate and send standalone report of PS Members whose CC Contacts have unsubscribed')
+
+    parser.add_argument('--no-sync',
+                        default=False,
+                        action='store_true',
+                        help='Skip sync execution and sync notification emails; '
+                             'all computation still runs; unlike --dry-run, '
+                             'allows --unsubscribed-report to send emails')
+
+    parser.add_argument('--dry-run',
+                        default=False,
+                        action='store_true',
+                        help='Log actions without executing; no emails sent; '
+                             'implies --verbose')
+
+    parser.add_argument('--verbose',
+                        default=False,
+                        action='store_true',
+                        help='Emit extra status messages during run')
+
+    parser.add_argument('--debug',
+                        default=False,
+                        action='store_true',
+                        help='Emit debug-level messages; implies --verbose')
+
+    parser.add_argument('--logfile',
+                        default='log.txt',
+                        help='File for verbose/debug log output')
+
+    args = parser.parse_args()
+
+    # --dry-run implies --verbose
+    if args.dry_run:
+        args.verbose = True
+
+    # --debug implies --verbose
+    if args.debug:
+        args.verbose = True
+
+    return args
+
+####################################################################
+
+def main():
+    args = setup_cli_args()
+
+    log = ECC.setup_logging(info=args.verbose,
+                            debug=args.debug,
+                            logfile=args.logfile, rotate=True,
+                            slack_token_filename=None)
+
+    # Authenticate with Constant Contact (early, so --cc-auth-only
+    # does not require PS credentials)
+    log.info("Authenticating with Constant Contact...")
+    cc_client_id = CC.load_client_id(args.cc_client_id, log)
+    cc_access_token = CC.get_access_token(args.cc_access_token,
+                                          cc_client_id, log)
+    if args.cc_auth_only:
+        log.info("Only authenticating to Constant Contact; exiting")
+        exit(0)
+
+    # Read the PS API key (deferred until after --cc-auth-only so that
+    # --cc-auth-only does not require PS credentials)
+    if not args.ps_api_keyfile:
+        log.error("--ps-api-keyfile is required")
+        exit(1)
+    if not os.path.exists(args.ps_api_keyfile):
+        log.error(f"ParishSoft API keyfile does not exist: {args.ps_api_keyfile}")
+        exit(1)
+    with open(args.ps_api_keyfile) as fp:
+        args.api_key = fp.read().strip()
+
+    # Set up email
+    ECC.setup_email(service_account_json=args.service_account_json,
+                    impersonated_user=args.impersonated_user,
+                    log=log)
+
+    # Phases 2-7 will be implemented in subsequent tasks
+
+if __name__ == '__main__':
+    main()

--- a/python/ConstantContact.py
+++ b/python/ConstantContact.py
@@ -4,7 +4,6 @@ import os
 import json
 import copy
 import random
-import inspect
 import datetime
 import requests
 
@@ -72,25 +71,6 @@ def api_get_all(client_id, access_token,
     log.info(f"Loaded {len(items)} total items")
 
     return items
-
-def api_get(client_id, access_token, uuid,
-               api_endpoint, log, include=None):
-    headers, params = api_headers(client_id, access_token,
-                                     include=include)
-
-    url = f"{client_id['endpoints']['api']}/v3/{api_endpoint}/{uuid}"
-    log.info(f"Loading a single Constant Contact item from endpoint {api_endpoint}")
-
-    log.debug(f"Getting URL: {url}")
-    # JMS Need to surround this in a retry
-    r = requests.get(url, headers=headers, params=params)
-    if r.status_code < 200 or r.status_code > 299:
-        log.error(f"Got a non-2xx GET status: {r.status_code}")
-        log.error(r.text)
-        exit(1)
-
-    response = json.loads(r.text)
-    return response
 
 def _api_put_or_post(action_fn, action_name,
                      client_id, access_token,
@@ -208,7 +188,7 @@ def oauth2_device_flow(client_id, log):
     _ = input("Hit enter when you have successfully completed that authorization: ")
 
     # Record the timestamp before we request the access token
-    start = datetime.datetime.utcnow()
+    start = datetime.datetime.now(datetime.timezone.utc)
 
     # Now get an access token
     device_code = response['device_code']
@@ -235,7 +215,7 @@ def oauth2_device_flow(client_id, log):
 # to a the token URL requesting a refresh.
 def oauth2_device_flow_refresh(client_id, access_token, log):
     # Record the timestamp before we request the access token
-    start = datetime.datetime.utcnow()
+    start = datetime.datetime.now(datetime.timezone.utc)
 
     post_data = {
         "client_id" : client_id['client id'],
@@ -284,6 +264,16 @@ def load_access_token(filename, log):
     vfrom = datetime.datetime.fromisoformat(access_token['valid from'])
     vto = datetime.datetime.fromisoformat(access_token['valid to'])
 
+    # The "valid from" and "valid to" fields are computed by our code
+    # (in set_valid_from_to()) from local UTC timestamps.  Older token
+    # files were saved with naive datetimes (via utcnow()); ensure they
+    # are tagged as UTC so that comparisons with timezone-aware
+    # datetimes don't raise TypeError.
+    if vfrom.tzinfo is None:
+        vfrom = vfrom.replace(tzinfo=datetime.timezone.utc)
+    if vto.tzinfo is None:
+        vto = vto.replace(tzinfo=datetime.timezone.utc)
+
     access_token['valid from'] = vfrom
     access_token['valid to'] = vto
     log.debug(f"Read: {access_token}")
@@ -314,7 +304,7 @@ def get_access_token(access_token_filename, client_id, log):
         exit(1)
 
     # Check to ensure that the access token is still valid.
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     log.debug(f"Valid from: {access_token['valid from']}")
     log.debug(f"Now:        {now}")
     log.debug(f"Valid to:   {access_token['valid to']}")

--- a/python/ConstantContact.py
+++ b/python/ConstantContact.py
@@ -31,6 +31,24 @@ class CCAPIError(Exception):
 #
 ####################################################################
 
+def _create_session(allowed_methods=None):
+    if allowed_methods is None:
+        allowed_methods = ["GET", "PUT", "POST"]
+
+    retry = Retry(
+        total=3,
+        backoff_factor=0.2,
+        status_forcelist=[429],
+        allowed_methods=allowed_methods,
+        respect_retry_after_header=True,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+
+    session = requests.Session()
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
 def api_headers(client_id, access_token, include=None, limit=None, status=None):
     headers = {
         'Authorization' : f'Bearer {access_token["access_token"]}',

--- a/python/ConstantContact.py
+++ b/python/ConstantContact.py
@@ -79,31 +79,31 @@ def api_get_all(client_id, access_token,
 
     items = list()
     url = base_url
-    while url:
-        log.debug(f"Getting URL: {url}")
-        # JMS Need to surround this in a retry
-        r = requests.get(url, headers=headers, params=params)
-        if r.status_code < 200 or r.status_code > 299:
-            log.error(f"Got a non-2xx GET (all) status: {r.status_code}")
-            log.error(r.text)
-            exit(1)
+    with _create_session(allowed_methods=["GET"]) as session:
+        while url:
+            log.debug(f"Getting URL: {url}")
+            r = session.get(url, headers=headers, params=params)
+            if r.status_code < 200 or r.status_code > 299:
+                log.error(f"Got a non-2xx GET (all) status: {r.status_code}")
+                log.error(r.text)
+                raise CCAPIError(r.status_code, r.text, api_endpoint)
 
-        response = json.loads(r.text)
-        for item in response[json_response_field]:
-            items.append(item)
-        log.debug(f"Loaded {len(response[json_response_field])} items")
+            response = json.loads(r.text)
+            for item in response[json_response_field]:
+                items.append(item)
+            log.debug(f"Loaded {len(response[json_response_field])} items")
 
-        url = None
-        key = '_links'
-        key2 = 'next'
-        if key in response and key2 in response[key]:
-            url = f"{client_id['endpoints']['api']}{response[key][key2]['href']}"
+            url = None
+            key = '_links'
+            key2 = 'next'
+            if key in response and key2 in response[key]:
+                url = f"{client_id['endpoints']['api']}{response[key][key2]['href']}"
 
     log.info(f"Loaded {len(items)} total items")
 
     return items
 
-def _api_put_or_post(action_fn, action_name,
+def _api_put_or_post(action_name,
                      client_id, access_token,
                      api_endpoint, body, log):
     headers, params = api_headers(client_id, access_token)
@@ -113,25 +113,27 @@ def _api_put_or_post(action_fn, action_name,
     log.info(f"Putting a single Constant Contact item to endpoint {api_endpoint}")
 
     log.debug(pformat(body))
-    r = action_fn(url, headers=headers,
-                  data=json.dumps(body))
+    with _create_session(allowed_methods=[action_name]) as session:
+        action_fn = getattr(session, action_name.lower())
+        r = action_fn(url, headers=headers,
+                      data=json.dumps(body))
     if r.status_code < 200 or r.status_code > 299:
         log.error(f"Got a non-2xx {action_name} status: {r.status_code}")
         log.error(r.text)
-        exit(1)
+        raise CCAPIError(r.status_code, r.text, api_endpoint)
 
     response = json.loads(r.text)
     return response
 
 def api_put(client_id, access_token,
             api_endpoint, body, log):
-    return _api_put_or_post(requests.put, "PUT",
+    return _api_put_or_post("PUT",
                             client_id, access_token, api_endpoint,
                             body, log)
 
 def api_post(client_id, access_token,
              api_endpoint, body, log):
-    return _api_put_or_post(requests.post, "POST",
+    return _api_put_or_post("POST",
                             client_id, access_token, api_endpoint,
                             body, log)
 

--- a/python/ConstantContact.py
+++ b/python/ConstantContact.py
@@ -6,11 +6,24 @@ import copy
 import random
 import datetime
 import requests
+from urllib3.util.retry import Retry
+from requests.adapters import HTTPAdapter
 
 from pprint import pprint
 from pprint import pformat
 
 import ParishSoftv2 as ParishSoft
+
+####################################################################
+
+class CCAPIError(Exception):
+    """Raised by API functions on non-2xx HTTP responses after retry exhaustion."""
+
+    def __init__(self, status_code, response_text, endpoint):
+        self.status_code = status_code
+        self.response_text = response_text
+        self.endpoint = endpoint
+        super().__init__(f"CC API error on {endpoint}: HTTP {status_code}")
 
 ####################################################################
 #

--- a/python/ConstantContact.py
+++ b/python/ConstantContact.py
@@ -110,7 +110,7 @@ def _api_put_or_post(action_name,
     headers['Content-Type'] = 'application/json'
 
     url = f"{client_id['endpoints']['api']}/v3/{api_endpoint}"
-    log.info(f"Putting a single Constant Contact item to endpoint {api_endpoint}")
+    log.info(f"{action_name} a single Constant Contact item to endpoint {api_endpoint}")
 
     log.debug(pformat(body))
     with _create_session(allowed_methods=[action_name]) as session:

--- a/python/ParishSoftv2.py
+++ b/python/ParishSoftv2.py
@@ -349,7 +349,7 @@ def _post_paginated_endpoint(session, endpoint, params, cache_dir, log,
                              offset_name='Offset', offset_type='index',
                              kwargs=None):
     if kwargs:
-        elements = _load_keyed_cache(endpoint, cache_dir, log_kwargs)
+        elements = _load_keyed_cache(endpoint, cache_dir, log, kwargs)
     else:
         elements = _load_cache(endpoint, cache_dir, log)
     if elements is not None:
@@ -615,11 +615,6 @@ def _load_family_workgroup_memberships(session, family_workgroups,
             'membership' : elements,
         }
 
-        first = True
-        if first:
-            log.debug(pformat(wg))
-            first = False
-
     return results
 
 #-----------------------------------------------------------------------------
@@ -844,7 +839,8 @@ def _link_family_workgroups(families, family_workgroup_memberships, log):
 
 def _link_family_pledges(families, pledges, log):
     if pledges is None:
-        family['py pledges'] = []
+        for family in families.values():
+            family['py pledges'] = []
         return
 
     for pledge in pledges.values():
@@ -861,7 +857,8 @@ def _link_family_pledges(families, pledges, log):
 
 def _link_family_contributions(families, contributions, log):
     if contributions is None:
-        family['py contributions'] = []
+        for family in families.values():
+            family['py contributions'] = []
         return
 
     for id, contribution in contributions.items():
@@ -1082,7 +1079,7 @@ def _family_wg_emails_internal(family, member_workgroups, name, log):
     # any Members in the Family with Head, Husband, or Wife as their
     # Role.
     heads = get_family_heads(family)
-    for memember in heads.values():
+    for member in heads.values():
         e = member['emailAddress']
         if not e:
             continue

--- a/specs/constantcontact/spec.md
+++ b/specs/constantcontact/spec.md
@@ -1,0 +1,402 @@
+# ConstantContact Module Specification
+
+**Module**: `python/ConstantContact.py`
+**Purpose**: Helper module for applications that interact with the Constant Contact V3 REST API. Provides OAuth2 authentication (device flow), generic API operations (GET/PUT/POST), contact management, and cross-linking of Constant Contact data with ParishSoft member data.
+
+---
+
+## 1. Overview
+
+ConstantContact is a data-access and synchronization layer that:
+
+1. Authenticates with the Constant Contact V3 API using OAuth2 device flow
+2. Manages access token lifecycle (obtain, persist, refresh, re-authorize)
+3. Provides generic paginated GET and PUT/POST API helpers
+4. Creates and updates contacts at Constant Contact
+5. Cross-links CC contacts, custom fields, and lists into an interconnected in-memory data model
+6. Links CC contacts to ParishSoft members by email address
+
+**API Base URL**: Configurable via `client_id['endpoints']['api']`, typically `https://api.cc.email`
+**Auth Endpoints**: Configurable via `client_id['endpoints']['auth']` and `client_id['endpoints']['token']`
+
+---
+
+## 2. Public API
+
+### 2.1 Authentication
+
+#### `load_client_id(filename, log) -> dict`
+
+Loads the CC client ID configuration from a JSON file. The file contains:
+
+```json
+{
+    "client id": "<client_id_string>",
+    "client secret": "<client_secret_string>",
+    "endpoints": {
+        "api": "https://api.cc.email",
+        "auth": "https://authz.constantcontact.com/oauth2/default/v1/device/authorize",
+        "token": "https://authz.constantcontact.com/oauth2/default/v1/token"
+    }
+}
+```
+
+**Note**: The `client secret` is present in the file but is not currently used by the code (the device flow does not require it).
+
+#### `get_access_token(access_token_filename, client_id, log) -> dict`
+
+**Primary authentication entry point.** Loads or obtains a valid CC OAuth2 access token.
+
+**Logic**:
+1. If `access_token_filename` does not exist: run device flow, save token
+2. If file exists: load token from file
+3. If token is not yet valid (`valid from > now`): error and exit
+4. If token is expired (`now > valid to`): attempt refresh; if refresh fails, run device flow again
+
+Returns an access token dict containing `access_token`, `refresh_token`, `expires_in`, `valid from`, `valid to`.
+
+#### `oauth2_device_flow(client_id, log) -> dict`
+
+Implements the CC OAuth2 Device Flow:
+
+1. POSTs to the auth endpoint with `client_id`, `response type: "code"`, `scope: "contact_data offline_access"`, and a random `state` value
+2. Displays a verification URL for the user to visit in a browser
+3. Waits for user confirmation (interactive `input()` prompt)
+4. POSTs to the token endpoint with `client_id`, `device_code`, and `grant_type: "urn:ietf:params:oauth:grant-type:device_code"`
+5. Returns the token response with `valid from` and `valid to` added
+
+#### `oauth2_device_flow_refresh(client_id, access_token, log) -> dict | None`
+
+Refreshes an expired access token:
+
+1. POSTs to the token endpoint with `client_id`, `refresh_token`, and `grant_type: "refresh_token"`
+2. Returns `None` on error (logs the error)
+
+**Discrepancy**: The CC API docs state that refresh requires a `Base64(client_id:client_secret)` Authorization header. The code passes `client_id` as a POST body parameter and does not include a client secret. This works in practice, likely because the device flow does not require a client secret (unlike the Authorization Code flow).
+
+#### `save_access_token(filename, access_token, log)`
+
+Serializes the access token to a JSON file. Converts `datetime.datetime` objects (`valid from`, `valid to`) to ISO format strings for JSON compatibility.
+
+#### `load_access_token(filename, log) -> dict`
+
+Loads an access token from a JSON file. Converts ISO format strings back to `datetime.datetime` objects.
+
+#### `set_valid_from_to(start, response)`
+
+Adds `valid from` (a `datetime.datetime`) and `valid to` (computed as `start + expires_in seconds`) to a token response dict.
+
+### 2.2 Generic API Operations
+
+#### `api_headers(client_id, access_token, include=None, limit=None, status=None) -> tuple[dict, dict]`
+
+Builds HTTP headers and query parameters for CC API calls.
+
+**Headers**: `Authorization: Bearer {access_token}`, `Cache-Control: no-cache`
+**Params**: Optional `include`, `limit`, `status` query parameters.
+
+#### `api_get_all(client_id, access_token, api_endpoint, json_response_field, log, include=None, status=None) -> list`
+
+Fetches all items from a paginated CC V3 endpoint.
+
+**Pagination**: Uses `_links.next.href` from each response to follow pages. Requests `limit=500` (the CC maximum). Stops when no `_links.next` is present.
+
+**Parameters**:
+- `api_endpoint`: Path relative to `/v3/` (e.g., `"contacts"`, `"contact_lists"`, `"contact_custom_fields"`)
+- `json_response_field`: Key in the JSON response containing the data array (e.g., `"contacts"`, `"lists"`, `"custom_fields"`)
+- `include`: Comma-separated subresources (e.g., `"custom_fields,list_memberships,street_addresses"`)
+- `status`: Contact status filter (e.g., `"all"` to include deleted/unsubscribed)
+
+**Error handling**: Exits with code 1 on non-2xx responses.
+
+#### `api_put(client_id, access_token, api_endpoint, body, log) -> dict`
+
+PUTs a JSON body to a CC V3 endpoint. Used for updating existing contacts.
+
+**Error handling**: Exits with code 1 on non-2xx responses.
+
+#### `api_post(client_id, access_token, api_endpoint, body, log) -> dict`
+
+POSTs a JSON body to a CC V3 endpoint. Used for creating/updating contacts via sign-up form.
+
+**Error handling**: Exits with code 1 on non-2xx responses.
+
+### 2.3 Contact Management
+
+#### `update_contact_full(contact, client_id, access_token, log)`
+
+Updates an existing CC contact using the PUT endpoint (`/v3/contacts/{contact_id}`).
+
+**Use case**: Unsubscribing contacts from lists. The sign-up form POST endpoint can only *add* list memberships; this PUT endpoint can *remove* them.
+
+**Design note**: The existence of two separate functions for writing contacts (`update_contact_full` and `create_or_update_contact`) is a workaround for the CC API's split behavior. A future consolidation into a single function is intended.
+
+**Request body** includes `update_source: "Contact"` and copies these fields from the contact if present: `first_name`, `last_name`, `email_address` (full object), `job_title`, `company_name`, `birthday_month`, `birthday_day`, `anniversary`, `street_addresses`, `list_memberships`.
+
+**Known workaround**: Strips periods from `first_name` because CC rejects names containing periods (e.g., `"T.J."` becomes `"TJ"`).
+
+#### `create_or_update_contact(contact, client_id, access_token, log)`
+
+Creates a new contact or updates an existing one via the sign-up form endpoint (`/v3/contacts/sign_up_form`).
+
+**Use case**: Adding new contacts or adding contacts to lists. Cannot unsubscribe from lists.
+
+**Key difference from `update_contact_full`**: Uses `email_address` as a simple string (`contact['email_address']['address']`) rather than the full email address object.
+
+**Request body** includes the email string and copies these fields from the contact if present: `first_name`, `last_name`, `job_title`, `company_name`, `birthday_month`, `birthday_day`, `anniversary`, `street_addresses`, `list_memberships`.
+
+**Known workaround**: Same period-stripping for `first_name`.
+
+#### `create_contact_dict(email, ps_members, log) -> dict`
+
+Creates a CC contact data structure in local memory (does not make any API call).
+
+**Returns** a dict with:
+- `email_address`: `{'address': email.lower()}`
+- `first_name`, `last_name`: Computed from ParishSoft members via `ParishSoft.salutation_for_members()`
+- `list_memberships`: Empty list (to be populated later)
+- `LIST MEMBERSHIPS`: Empty list (human-readable names, populated during linking)
+- `PS MEMBERS`: Reference to the ParishSoft member list
+
+Also sets `member['CONTACT'] = contact` on each PS member, creating a back-reference.
+
+### 2.4 Data Linking
+
+#### `link_cc_data(contacts, custom_fields_arg, lists_arg, log)`
+
+Cross-references CC contacts with custom fields and lists. Creates enriched data structures for human-readable access.
+
+**Custom field linking**:
+- Builds a lookup dict of custom fields by `custom_field_id`
+- For each contact, resolves custom field UUIDs to names
+- Stores in `contact['CUSTOM FIELDS']` (dict keyed by field name)
+
+**List linking**:
+- Builds a lookup dict of lists by `list_id`
+- For each contact, resolves list membership UUIDs to names
+- Stores human-readable names in `contact['LIST MEMBERSHIPS']` (list of strings)
+- Builds reverse index: `list['CONTACTS'][email] = contact`
+
+#### `link_contacts_to_ps_members(contacts, ps_members, log)`
+
+Cross-references CC contacts with ParishSoft members by email address.
+
+1. Builds a lookup of PS members by their first email address (`py emailAddresses[0]`)
+2. For each CC contact, if the email matches a PS member:
+   - Sets `contact['PS MEMBERS']` = list of matching PS members
+   - Sets `member['CONTACT']` = back-reference to the CC contact
+
+### 2.5 Function Classification
+
+Verified against the sole consumer (`sync-constant-contact.py`):
+
+**Consumer-facing** (called directly by consumer):
+
+| Function | Consumer Lines |
+|---|---|
+| `load_client_id()` | 1015 |
+| `get_access_token()` | 1016 |
+| `api_get_all()` | 1024, 1031, 1038 |
+| `create_contact_dict()` | 591 |
+| `create_or_update_contact()` | 741 |
+| `update_contact_full()` | 759 |
+| `link_cc_data()` | 1065 |
+| `link_contacts_to_ps_members()` | 1078 |
+
+**Internal** (used within the module's call chain, not called by consumer):
+
+| Function | Called By |
+|---|---|
+| `api_headers()` | `api_get_all`, `_api_put_or_post` |
+| `_api_put_or_post()` | `api_put`, `api_post` |
+| `api_put()` | `update_contact_full` |
+| `api_post()` | `create_or_update_contact` |
+| `set_valid_from_to()` | `oauth2_device_flow`, `oauth2_device_flow_refresh` |
+| `oauth2_device_flow()` | `get_access_token` |
+| `oauth2_device_flow_refresh()` | `get_access_token` |
+| `save_access_token()` | `get_access_token` |
+| `load_access_token()` | `get_access_token` |
+
+---
+
+## 3. Data Model
+
+### 3.1 Client ID Structure
+
+```json
+{
+    "client id": "string",
+    "client secret": "string",
+    "endpoints": {
+        "api": "https://api.cc.email",
+        "auth": "https://authz.constantcontact.com/oauth2/default/v1/device/authorize",
+        "token": "https://authz.constantcontact.com/oauth2/default/v1/token"
+    }
+}
+```
+
+**Note**: `client secret` is stored in the file but not used by the code (device flow clients are public).
+
+### 3.2 Access Token Structure
+
+```json
+{
+    "access_token": "JWT string (1000-1200 chars)",
+    "refresh_token": "string (42 chars)",
+    "expires_in": 28800,
+    "token_type": "Bearer",
+    "scope": "contact_data offline_access",
+    "valid from": "datetime.datetime (ISO string when persisted)",
+    "valid to": "datetime.datetime (ISO string when persisted)"
+}
+```
+
+### 3.3 Contact Enrichments
+
+After `link_cc_data` and `link_contacts_to_ps_members`:
+
+| Key | Type | Source |
+|-----|------|--------|
+| `CUSTOM FIELDS` | `dict[str, dict]` | Keyed by custom field name |
+| `LIST MEMBERSHIPS` | `list[str]` | Human-readable list names |
+| `PS MEMBERS` | `list[dict]` | ParishSoft member objects |
+
+### 3.4 List Enrichments
+
+After `link_cc_data`:
+
+| Key | Type | Source |
+|-----|------|--------|
+| `CONTACTS` | `dict[str, dict]` | Keyed by email address, values are contact objects |
+
+---
+
+## 4. Cross-Reference with CC V3 API Documentation
+
+**Source**: https://developer.constantcontact.com/api_guide/index.html
+
+### 4.1 Endpoints Used
+
+| Code Function | CC V3 Endpoint | Method | Purpose |
+|---|---|---|---|
+| `api_get_all` | `/v3/contacts` | GET | Download all contacts with pagination |
+| `api_get_all` | `/v3/contact_lists` | GET | Download all contact lists |
+| `api_get_all` | `/v3/contact_custom_fields` | GET | Download all custom fields |
+| `api_put` (via `update_contact_full`) | `/v3/contacts/{contact_id}` | PUT | Update existing contact (incl. list unsubscribe) |
+| `api_post` (via `create_or_update_contact`) | `/v3/contacts/sign_up_form` | POST | Create or update contact (subscribe only) |
+
+### 4.2 Endpoint Details: Code vs API Documentation
+
+| Aspect | Code Behavior | API Documentation | Discrepancies |
+|---|---|---|---|
+| **GET pagination** | Follows `_links.next.href`, `limit=500` | Pagination via `_links.next.href`, max `limit=500` | Matches |
+| **GET contacts params** | Uses `include`, `status`, `limit` | Supports `include`, `status`, `limit`, plus `email`, `lists`, `segment_id`, `tags`, `updated_after`, `created_after` | Code doesn't use all available filters — this is fine for bulk download use case |
+| **PUT contacts** | Sends `update_source: "Contact"` | Requires `update_source` field | Matches. API docs say `"Account"` or `"Contact"` |
+| **PUT email_address** | Passes full `email_address` object from contact | Expects object with `address` and optional `permission_to_send` | Matches |
+| **POST sign_up_form** | Sends `email_address` as plain string | Expects `email_address` as string (max 50 chars) | Matches |
+| **POST sign_up_form** | Sends `list_memberships` array | Requires at least 1 list, max 50 | Code may send empty `list_memberships` for newly created contacts before lists are assigned — this could fail at the CC API |
+| **OAuth2 device flow** | Sends `response type: "code"` | API docs show `client_id` and `scope` as required | Minor: code sends extra `response type` and `state` params — likely ignored by server |
+| **OAuth2 refresh** | POSTs `client_id` + `refresh_token` + `grant_type` as form data | Docs say to use `Authorization: Basic Base64(client_id:client_secret)` header | Code omits client secret; works because device flow clients are public (no secret required) |
+| **Token validity** | Uses `datetime.datetime.now(datetime.timezone.utc)` for comparison | Tokens valid for 1440 min (24h) per docs; `expires_in` in response | Matches |
+
+### 4.3 API Features NOT Used by Code
+
+| CC V3 Feature | Endpoint | Notes |
+|---|---|---|
+| Delete contact | `DELETE /v3/contacts/{contact_id}` | Consumer has placeholder code for deletion but it's not yet implemented |
+| Bulk import contacts | `POST /v3/activities/contacts_file_import` | Code creates/updates contacts one at a time |
+| Bulk delete contacts | `POST /v3/activities/contact_delete` | Not used |
+| Bulk list add/remove | `POST /v3/activities/add_list_memberships`, `POST /v3/activities/remove_list_memberships` | Code modifies lists via individual contact updates |
+| Contact tags | `/v3/contact_tags` | Not used |
+| Segments | `/v3/segments` | Not used |
+| Email campaigns | `/v3/emails` | Not used (out of scope for sync module) |
+| Contact consent counts | `GET /v3/contacts/counts` | Not used |
+
+### 4.4 Rate Limits
+
+The CC V3 API enforces:
+- **4 requests per second** per API key
+- **10,000 requests per day** per API key (resets at UTC 00:00:00)
+- HTTP 429 "Too Many Requests" when exceeded
+
+See Section 6.2 for the known gap regarding rate limit handling in the code.
+
+---
+
+## 5. Authentication Flow
+
+The module uses the CC OAuth2 **Device Flow** (flow #3 of 4 available):
+
+```
+1. POST to auth endpoint → receive device_code + verification URL
+2. User visits URL in browser, authenticates, grants permission
+3. User confirms in terminal (interactive prompt)
+4. POST to token endpoint with device_code → receive access_token + refresh_token
+5. Save token to JSON file for reuse
+```
+
+**Token lifecycle**:
+- Access tokens expire after ~24 hours (`expires_in` from API, typically 1440 minutes)
+- Refresh tokens expire after 180 days if unused
+- On expiry: attempt refresh → if that fails, re-run device flow (requires user interaction)
+
+**Scopes requested**: `contact_data` (read/write contacts) and `offline_access` (enables refresh tokens)
+
+---
+
+## 6. Error Handling and Known Gaps
+
+All API operations (`api_get_all`, `api_put`, `api_post`) exit with code 1 on any non-2xx HTTP response. There is no retry logic for transient failures.
+
+### 6.1 Known Gap: No Retry Logic
+
+The code has no retry/backoff for transient HTTP errors or CC rate limit (429) responses. Code comments (`# JMS Need to surround this in a retry`) confirm this is a known gap. Compare with `ParishSoftv2.py`, which uses `urllib3.util.Retry` with 3 retries and 0.2s backoff.
+
+### 6.2 Known Gap: No Rate Limiting
+
+The CC V3 API enforces 4 requests/second and 10,000 requests/day. The code does not throttle requests. For the current cron-based use case this has not been a problem, but could become one as the contact list grows or if the sync runs more frequently.
+
+---
+
+## 7. Dependencies
+
+- `requests` — HTTP client (no retry adapter, unlike ParishSoftv2)
+- `ParishSoftv2` (imported as `ParishSoft`) — used only for `salutation_for_members()` in `create_contact_dict()`
+- Standard library: `os`, `json`, `copy`, `random`, `datetime`
+- `pprint` — for debug logging
+
+
+---
+
+## 8. Consumer Usage Pattern
+
+The sole consumer is `media/linux/ps-queries/sync-constant-contact.py`, which:
+
+1. **Authenticates**: `load_client_id()` + `get_access_token()`
+2. **Downloads all CC data**: Three `api_get_all()` calls for custom fields, lists, contacts
+3. **Links CC data**: `link_cc_data()` to cross-reference contacts/lists/custom fields
+4. **Links to ParishSoft**: `link_contacts_to_ps_members()` to match by email
+5. **Computes sync actions**: Determines which contacts need creating, updating, or unsubscribing
+6. **Creates missing contacts**: `create_contact_dict()` for contacts that exist in PS but not CC
+7. **Executes changes**:
+   - `create_or_update_contact()` for new contacts and list subscriptions
+   - `update_contact_full()` for list unsubscriptions
+
+---
+
+## 9. Pending Code Cleanup
+
+The following items should be addressed:
+
+1. **Consolidate `update_contact_full` and `create_or_update_contact`** — currently two separate functions as a workaround for CC API behavior; intended to be merged into a single function
+2. **Add retry logic** — `api_get_all` (and other API functions) lack retry/backoff; see Section 6.1
+
+---
+
+## 10. Reconciliation Summary
+
+**Reconciled**: 2026-03-01
+**API docs cross-referenced**: 2026-03-01 (CC V3 API guide at developer.constantcontact.com)
+
+This document was created to reflect the actual implementation of `python/ConstantContact.py`.
+The specification was derived from reading the source code, analyzing usage by its single consumer script (`sync-constant-contact.py`), and cross-referencing against the Constant Contact V3 API documentation.

--- a/specs/constantcontact/spec.md
+++ b/specs/constantcontact/spec.md
@@ -88,6 +88,17 @@ Adds `valid from` (a `datetime.datetime`) and `valid to` (computed as `start + e
 
 ### 2.2 Generic API Operations
 
+#### `CCAPIError` (Exception Class)
+
+Custom exception raised by API functions on non-2xx HTTP responses (after retry exhaustion).
+
+**Attributes**:
+- `status_code`: The HTTP status code
+- `response_text`: The response body text
+- `endpoint`: The API endpoint that failed
+
+Consumers should catch this exception to handle individual API failures gracefully (e.g., log and continue processing remaining contacts).
+
 #### `api_headers(client_id, access_token, include=None, limit=None, status=None) -> tuple[dict, dict]`
 
 Builds HTTP headers and query parameters for CC API calls.
@@ -107,19 +118,19 @@ Fetches all items from a paginated CC V3 endpoint.
 - `include`: Comma-separated subresources (e.g., `"custom_fields,list_memberships,street_addresses"`)
 - `status`: Contact status filter (e.g., `"all"` to include deleted/unsubscribed)
 
-**Error handling**: Exits with code 1 on non-2xx responses.
+**Error handling**: Raises `CCAPIError` on non-2xx responses after retry exhaustion.
 
 #### `api_put(client_id, access_token, api_endpoint, body, log) -> dict`
 
 PUTs a JSON body to a CC V3 endpoint. Used for updating existing contacts.
 
-**Error handling**: Exits with code 1 on non-2xx responses.
+**Error handling**: Raises `CCAPIError` on non-2xx responses after retry exhaustion.
 
 #### `api_post(client_id, access_token, api_endpoint, body, log) -> dict`
 
 POSTs a JSON body to a CC V3 endpoint. Used for creating/updating contacts via sign-up form.
 
-**Error handling**: Exits with code 1 on non-2xx responses.
+**Error handling**: Raises `CCAPIError` on non-2xx responses after retry exhaustion.
 
 ### 2.3 Contact Management
 
@@ -319,7 +330,7 @@ The CC V3 API enforces:
 - **10,000 requests per day** per API key (resets at UTC 00:00:00)
 - HTTP 429 "Too Many Requests" when exceeded
 
-See Section 6.2 for the known gap regarding rate limit handling in the code.
+See Section 6.2 for rate limit handling.
 
 ---
 
@@ -344,23 +355,35 @@ The module uses the CC OAuth2 **Device Flow** (flow #3 of 4 available):
 
 ---
 
-## 6. Error Handling and Known Gaps
+## 6. Error Handling
 
-All API operations (`api_get_all`, `api_put`, `api_post`) exit with code 1 on any non-2xx HTTP response. There is no retry logic for transient failures.
+All API operations (`api_get_all`, `api_put`, `api_post`) raise `CCAPIError` on non-2xx HTTP responses after retry exhaustion. Consumers are responsible for catching these exceptions and deciding how to handle them (e.g., abort, log and continue, etc.).
 
-### 6.1 Known Gap: No Retry Logic
+### 6.1 Retry Logic
 
-The code has no retry/backoff for transient HTTP errors or CC rate limit (429) responses. Code comments (`# JMS Need to surround this in a retry`) confirm this is a known gap. Compare with `ParishSoftv2.py`, which uses `urllib3.util.Retry` with 3 retries and 0.2s backoff.
+API calls use `requests.Session` with an `HTTPAdapter` configured with `urllib3.util.Retry`:
+- **Retries**: 3
+- **Backoff factor**: 0.2 seconds
+- **Retry on**: Connection errors, transient HTTP errors, and 429 (Too Many Requests) responses
 
-### 6.2 Known Gap: No Rate Limiting
+This matches the retry strategy used by `ParishSoftv2.py`.
 
-The CC V3 API enforces 4 requests/second and 10,000 requests/day. The code does not throttle requests. For the current cron-based use case this has not been a problem, but could become one as the contact list grows or if the sync runs more frequently.
+### 6.2 Rate Limit Handling
+
+The CC V3 API enforces 4 requests/second and 10,000 requests/day (see Section 4.4). The module handles rate limiting reactively:
+
+- HTTP 429 responses are retried automatically by the retry adapter
+- The `Retry-After` header from 429 responses is respected for backoff timing
+- There is no proactive request throttling; rate limiting is purely reactive
+
+Note: For the current cron-based use case (running every 15 minutes with a moderate number of contacts), proactive throttling is not necessary.
 
 ---
 
 ## 7. Dependencies
 
-- `requests` — HTTP client (no retry adapter, unlike ParishSoftv2)
+- `requests` — HTTP client with `HTTPAdapter` configured with `urllib3.util.Retry` for automatic retry/backoff
+- `urllib3` — Provides `Retry` and backoff functionality (included as a dependency of `requests`)
 - `ParishSoftv2` (imported as `ParishSoft`) — used only for `salutation_for_members()` in `create_contact_dict()`
 - Standard library: `os`, `json`, `copy`, `random`, `datetime`
 - `pprint` — for debug logging
@@ -368,35 +391,49 @@ The CC V3 API enforces 4 requests/second and 10,000 requests/day. The code does 
 
 ---
 
-## 8. Consumer Usage Pattern
+## 8. Consumer Usage Patterns
 
-The sole consumer is `media/linux/ps-queries/sync-constant-contact.py`, which:
+### 8.1 sync-constant-contact.py (legacy)
+
+The original consumer script. See its source for details.
+
+### 8.2 sync-ps-to-cc.py
+
+The replacement consumer script (see `specs/sync-ps-to-cc/spec.md`). Usage pattern:
 
 1. **Authenticates**: `load_client_id()` + `get_access_token()`
-2. **Downloads all CC data**: Three `api_get_all()` calls for custom fields, lists, contacts
-3. **Links CC data**: `link_cc_data()` to cross-reference contacts/lists/custom fields
+2. **Downloads CC data**: Two `api_get_all()` calls for lists and contacts (no custom fields)
+3. **Links CC data**: `link_cc_data()` with empty custom fields to cross-reference contacts/lists
 4. **Links to ParishSoft**: `link_contacts_to_ps_members()` to match by email
-5. **Computes sync actions**: Determines which contacts need creating, updating, or unsubscribing
+5. **Computes sync actions**: Determines which contacts need creating, subscribing, or unsubscribing
 6. **Creates missing contacts**: `create_contact_dict()` for contacts that exist in PS but not CC
-7. **Executes changes**:
+7. **Executes changes** (catching `CCAPIError` per-contact to log and continue):
    - `create_or_update_contact()` for new contacts and list subscriptions
-   - `update_contact_full()` for list unsubscriptions
+   - `update_contact_full()` for list unsubscriptions and name updates
 
 ---
 
 ## 9. Pending Code Cleanup
 
-The following items should be addressed:
+The following item should be addressed:
 
 1. **Consolidate `update_contact_full` and `create_or_update_contact`** — currently two separate functions as a workaround for CC API behavior; intended to be merged into a single function
-2. **Add retry logic** — `api_get_all` (and other API functions) lack retry/backoff; see Section 6.1
 
 ---
 
 ## 10. Reconciliation Summary
 
 **Reconciled**: 2026-03-01
+**Updated**: 2026-03-01 (planned changes for retry logic, rate limiting, exception-based error handling)
 **API docs cross-referenced**: 2026-03-01 (CC V3 API guide at developer.constantcontact.com)
 
-This document was created to reflect the actual implementation of `python/ConstantContact.py`.
-The specification was derived from reading the source code, analyzing usage by its single consumer script (`sync-constant-contact.py`), and cross-referencing against the Constant Contact V3 API documentation.
+This document was originally created to reflect the actual implementation of `python/ConstantContact.py`.
+The specification was derived from reading the source code, analyzing usage by its consumer scripts, and cross-referencing against the Constant Contact V3 API documentation.
+
+Sections 2.2, 6, and 7 were updated on 2026-03-01 to specify planned changes:
+- `CCAPIError` exception class (replacing `exit(1)` calls)
+- Retry logic via `urllib3.util.Retry`
+- Reactive rate limit handling (429 + Retry-After)
+- Updated consumer usage patterns for `sync-ps-to-cc.py`
+
+These changes have not yet been implemented in code.

--- a/specs/msp/spec.md
+++ b/specs/msp/spec.md
@@ -1,0 +1,451 @@
+# MSP Module Specification
+
+**Module**: `python/MSP.py`
+**Purpose**: Helper module for applications that interact with the Ministry Scheduler Pro (MSP) REST API v2. Loads, caches, cross-links, and filters MSP data (volunteers, masses, ministries, services). Optionally cross-links MSP volunteers with ParishSoft member/family data.
+
+---
+
+## 1. Overview
+
+MSP.py is a data-access layer that:
+
+1. Wraps the MSP REST API v2 for CRUD-like operations (authenticate, read, create, update, delete)
+2. Downloads and caches MSP data as JSON files to avoid redundant API calls
+3. Cross-links MSP objects (volunteers, masses, ministries, services) into an interconnected in-memory data model
+4. Optionally cross-links MSP volunteers to ParishSoft members and families
+5. Filters data based on active status and date ranges
+6. Exposes public query functions for ministry membership lookups
+
+**Data ownership**: ParishSoft is the source of truth for member data. All synchronization flows from ParishSoft to MSP — never the reverse. MSP volunteers are created, updated, deactivated, or deleted based on ParishSoft member status.
+
+**Design principle**: MSP.py is strictly a data-access and cross-linking layer. Higher-level business logic — such as determining which MSP volunteers need to be created, deactivated, or reactivated based on ParishSoft member status — belongs in separate Python scripts that use MSP.py.
+
+**API Base URL**: `https://api.ministryschedulerpro.com/2`
+
+**API Documentation**: [MSP REST API v2 Reference](https://docs.google.com/document/u/0/d/e/2PACX-1vRO7Mg0gcBV8Id0X4ecc4vHJHFzV8r9f5o-cprqLHZu7REbKO1YWiUI0wk6Ko_DdbBEGxBeYZ81XCet/pub?pli=1)
+
+---
+
+## 2. Public API
+
+### 2.1 `load_msp_data()`
+
+**Primary entry point.** Downloads all MSP data, cross-links it, optionally links to ParishSoft data, filters it, and returns four dictionaries.
+
+```python
+def load_msp_data(
+    api_key=None,              # Required. MSP API key (already base64-encoded)
+    active_only=True,          # Filter out inactive volunteers/services
+    mass_start_date=None,      # Start date for mass loading (default: today)
+    mass_end_date=None,        # End date for mass loading (default: 3 months from today)
+    ps_members=None,           # Optional ParishSoft members dict (from ParishSoftv2)
+    ps_families=None,          # Optional ParishSoft families dict (from ParishSoftv2)
+    log=None,                  # Logger instance
+    cache_dir="msp-data",      # Directory for cache files
+    cache_limit="14m",         # Cache freshness ("14m", "1d", "24s", "7h")
+    timezone="America/Kentucky/Louisville",  # IANA timezone for MSP license
+) -> tuple:
+```
+
+**Returns**: `(volunteers, masses, ministries, services)`
+
+- `volunteers`: `dict[str|int, dict]` keyed by Volunteer ID
+- `masses`: `dict[str, dict]` keyed by Mass ID (composite `scheduleId_localMassId`)
+- `ministries`: `dict[str|int, dict]` keyed by Ministry ID
+- `services`: `dict[str|int, dict]` keyed by Service ID
+
+**Load sequence**:
+
+1. Parse `cache_limit` and set global cache freshness threshold
+2. Create `cache_dir` if it doesn't exist
+3. Set up HTTP session with Bearer token auth and retry logic (3 retries, 0.2s backoff)
+4. Load ministry data
+5. Load service data
+6. Load volunteer data
+7. Load mass data (filtered by date range)
+8. Cross-link all data (see Section 5)
+9. If ParishSoft data provided, cross-link volunteers to PS members (see Section 6)
+10. Filter data per `active_only` (see Section 7)
+11. Return the four dictionaries
+
+### 2.2 Volunteer Query Functions
+
+#### `get_ministry_volunteers(ministry, volunteers) -> dict`
+
+Returns a dict of volunteers (keyed by volunteer ID) who are qualified for the given ministry. Includes both standard and substitute volunteers.
+
+#### `get_ministry_subs(ministry, volunteers) -> dict`
+
+Returns a dict of volunteers (keyed by volunteer ID) who are substitutes (`"SUB"`) for the given ministry.
+
+#### `get_ministry_non_subs(ministry, volunteers) -> dict`
+
+Returns a dict of volunteers (keyed by volunteer ID) who are standard members (`"NONE"` or title-qualified) for the given ministry, excluding substitutes.
+
+#### `get_volunteer_ministries(volunteer) -> dict`
+
+Returns a dict of ministries (keyed by ministry ID) that the volunteer is qualified for, with their qualification level (`"NONE"`, `"SUB"`, or title ID).
+
+#### `volunteer_is_active(volunteer) -> bool`
+
+Returns `True` if the volunteer's `inactive` field is `False` (or absent).
+
+#### `volunteer_is_group(volunteer) -> bool`
+
+Returns `True` if the volunteer's `isGroup` field is `True`.
+
+### 2.3 CRUD Functions (Write Operations)
+
+Thin wrappers around the MSP REST API write endpoints. These functions handle authentication, HTTP mechanics, and cache invalidation. They do **not** contain business logic — callers are responsible for deciding what to create, update, or delete.
+
+#### `create_volunteer(api_key, fields, log, cache_dir="msp-data") -> dict`
+
+Creates a new volunteer. `fields` must include at minimum `firstName` and `lastName` (unless `isGroup` is `True`).
+
+- Sends `POST /volunteers` with the provided fields
+- Invalidates the volunteer cache on success
+- Returns the created volunteer dict from the API response
+
+#### `update_volunteer(api_key, volunteer_id, fields, log, cache_dir="msp-data") -> dict`
+
+Updates a single volunteer. `fields` is a dict of MSP volunteer properties to set.
+
+- Sends `PUT /volunteers/{volunteer_id}` with the provided fields
+- Invalidates the volunteer cache on success
+- Returns the updated volunteer dict from the API response
+
+#### `delete_volunteer(api_key, volunteer_id, log, cache_dir="msp-data") -> bool`
+
+Deletes a volunteer by ID.
+
+- Sends `DELETE /volunteers/{volunteer_id}`
+- Invalidates the volunteer cache on success
+- Returns `True` on success, calls `exit(1)` on critical failure
+
+---
+
+## 3. Caching System
+
+### 3.1 Cache Limit
+
+Uses the same humanized time string format as ParishSoftv2:
+- `s` = seconds, `m` = minutes, `h` = hours, `d` = days
+- Examples: `"24s"`, `"15m"`, `"7h"`, `"2d"`
+- Default: `"14m"` (designed for 15-minute cron intervals)
+
+Cache files older than the limit are re-fetched from the API.
+
+### 3.2 Cache Files
+
+Files stored as `cache-msp-{endpoint}.json` (with `/` and `:` replaced by `-`) in `cache_dir` (default: `msp-data`).
+
+- `_save_cache(endpoint, elements, cache_dir, log)`: Writes elements as JSON
+- `_load_cache(endpoint, cache_dir, log)`: Returns elements if file exists and is fresh, else `None`
+
+### 3.3 Cache Invalidation
+
+Write operations (create, update, delete) invalidate the relevant cache files by deleting them. This ensures subsequent reads fetch fresh data from the API.
+
+### 3.4 Cache Bypass
+
+When optional `where` clauses are provided to load functions, caching is bypassed entirely — the query is always sent to the API and the response is not cached. This is because filtered queries produce subsets that should not be confused with complete datasets.
+
+---
+
+## 4. API Interaction
+
+### 4.1 Authentication
+
+MSP uses HTTP Bearer token authentication:
+
+```
+Authorization: Bearer <api-key>
+```
+
+The API key is already base64-encoded as provided by MSP. No additional encoding is needed.
+
+### 4.2 HTTP Session
+
+- Uses `requests.Session` with `Authorization: Bearer <api-key>` header
+- Retry policy: 3 retries, 0.2s backoff factor, allowed on POST, GET, PUT, DELETE
+- All requests use `Accept: application/json` and `Content-Type: application/json`
+
+### 4.3 Pagination Workaround
+
+The MSP API supports pagination via `limit` and `startAt` parameters. However, there is a known behavior where setting `limit` to an arbitrarily large number (e.g., 1,000,000) returns all records in a single response without requiring pagination. MSP.py uses this approach for simplicity.
+
+This should be documented with inline comments in the code explaining the workaround and why explicit pagination is not used.
+
+### 4.4 Record ID Format
+
+For legacy reasons, MSP uses two ID formats:
+- **Integer IDs**: numeric (e.g., `374`)
+- **String IDs**: 18-character strings that begin with a lowercase `a` (e.g., `"a5f887a8300aee6006"`). The API documentation describes these as "alphanumeric", but in practice they appear to always be hexadecimal.
+
+Mass IDs are composite: `"{scheduleId}_{localMassId}"`.
+
+Code must handle both integer and string IDs. Dictionary keys should preserve the original type from the API.
+
+### 4.5 Date Format
+
+- Dates: `YYYY-MM-DD`
+- Timestamps: `YYYY-MM-DD HH:MM:SS` (in the license's local timezone)
+- `dateCreated` and `dateModified` are in UTC
+
+The MSP API returns non-UTC timestamps in the license's local timezone. The `timezone` parameter on `load_msp_data()` specifies the IANA timezone name for interpreting these timestamps. It defaults to `"America/Kentucky/Louisville"` (US Eastern, Louisville). This timezone is used when converting `dateTime` strings to timezone-aware `datetime` objects in cross-linking (e.g., `py datetime` on masses).
+
+### 4.6 Endpoints Used
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `GET /volunteers/{id}` | GET | Single volunteer lookup |
+| `POST /volunteers/list` | POST | Query/list all volunteers |
+| `POST /volunteers` | POST | Create volunteer |
+| `PUT /volunteers/{id}` | PUT | Update volunteer |
+| `DELETE /volunteers/{id}` | DELETE | Delete volunteer |
+| `GET /masses/{id}` | GET | Single mass lookup |
+| `POST /masses/list` | POST | Query/list masses |
+| `GET /ministries/{id}` | GET | Single ministry lookup |
+| `POST /ministries/list` | POST | Query/list all ministries |
+| `GET /services/{id}` | GET | Single service lookup |
+| `POST /services/list` | POST | Query/list all services |
+
+### 4.7 Query Format
+
+List endpoints (`POST /collection/list`) accept a JSON body with:
+
+```json
+{
+    "where": { ... },
+    "fields": ["field1", "field2"],
+    "limit": 1000000,
+    "startAt": 0
+}
+```
+
+- `where`: Optional filter conditions. Supports simple equality and operators like `isGreaterThan`, `isLessThan`.
+- `fields`: Optional array of properties to return (ID is always included).
+- `limit`: Set to a very large number to retrieve all records (see Section 4.3).
+- `startAt`: **Known documentation bug**: the MSP docs describe this as a pagination offset, but it is actually the record ID to start from — not an index. A `startAt` of `0` starts at the first record. If pagination were used, the next page would require `startAt` set to the last record's ID + 1, not the count of records already fetched.
+
+When `where` is not needed, pass `{"limit": 1000000}` to retrieve all records.
+
+---
+
+## 5. Data Cross-Linking
+
+After loading, the following cross-references are created (all prefixed with `py ` to match ParishSoftv2 convention):
+
+### Volunteer enrichments:
+- `py ministries`: dict keyed by ministry ID, values are qualification level (`"NONE"`, `"SUB"`, or title ID). Derived from the volunteer's `ministries` field.
+- `py ministry_objects`: dict keyed by ministry ID, values are the ministry dict objects
+- `py family_members`: list of other volunteer dicts sharing the same `familyId` (empty list if no familyId)
+- `py emails`: list of email addresses (split from comma-separated `email` field, lowercased)
+- `py cells`: list of cell phone numbers (split from comma-separated `cell` field)
+- `py phones`: list of phone numbers (split from comma-separated `phone` field)
+- `py scheduled_duties`: the volunteer's `scheduledDuties` field (preserved for convenience)
+- `py friendly name FL`: "First Last" using firstName/lastName
+- `py friendly name LF`: "Last, First" using firstName/lastName
+
+### Ministry enrichments:
+- `py volunteers`: dict keyed by volunteer ID, values are volunteer dict objects (only those present in the loaded volunteers dict)
+- `py subs`: dict keyed by volunteer ID, values are volunteer dict objects for substitute-qualified volunteers
+- `py services`: dict keyed by service ID, values are service dict objects that require this ministry
+
+### Service enrichments:
+- `py ministries`: dict keyed by ministry ID, values are ministry dict objects for ministries required at this service
+- `py masses`: list of mass dicts associated with this service (via `serviceId`)
+
+### Mass enrichments:
+- `py service`: the service dict object (via `serviceId`), or `None` if one-time mass
+- `py positions_enriched`: dict keyed by ministry ID, values are lists of position dicts where each position's `volunteerId` is resolved to the volunteer dict object (as `py volunteer`), and the `ministryId` is resolved to the ministry dict object (as `py ministry`)
+- `py date`: `datetime.date` object parsed from the `dateTime` field
+- `py datetime`: `datetime.datetime` object parsed from the `dateTime` field
+
+---
+
+## 6. ParishSoft Cross-Linking
+
+When `ps_members` and `ps_families` are provided to `load_msp_data()`, MSP volunteers are linked to ParishSoft members using a two-tier matching strategy. Since ParishSoft is the source of truth, this linkage enables downstream scripts to synchronize member data from ParishSoft into MSP.
+
+### 6.1 Matching Strategy
+
+1. **Primary match**: MSP volunteer `externalId` == ParishSoft Member DUID (converted to string for comparison)
+2. **Fallback match**: MSP volunteer `firstName`+`lastName` == ParishSoft member `firstName`+`lastName` (case-insensitive). Only used when `externalId` is not set or does not match any PS member.
+
+### 6.2 Volunteer Enrichments (when PS data is linked)
+
+- `py ps_member`: the ParishSoft member dict, or `None` if unlinked
+- `py ps_family`: the ParishSoft family dict (via the member's `py family` field), or `None` if unlinked
+- `py ps_member_duid`: the ParishSoft Member DUID, or `None` if unlinked
+
+### 6.3 PS Member Enrichments
+
+When cross-linking succeeds, the ParishSoft member dict also receives:
+- `py msp_volunteer`: the MSP volunteer dict, or `None` if no match
+
+### 6.4 Unlinked Volunteers
+
+Volunteers without a ParishSoft match have `py ps_member`, `py ps_family`, and `py ps_member_duid` set to `None`. The load function logs a warning for each unlinked volunteer to aid in data reconciliation.
+
+---
+
+## 7. Filtering
+
+Filtering happens after all cross-linking is complete.
+
+### Volunteer filtering:
+- `active_only=True`: removes volunteers where `volunteer_is_active()` returns `False` (i.e., `inactive` is `True`)
+
+### Service filtering:
+- `active_only=True`: removes services where `inactive` is `True`
+
+### Mass filtering:
+- Masses are filtered by date range during loading (via `where` clause on the API query)
+- `mass_start_date`: defaults to today
+- `mass_end_date`: defaults to 3 months from today
+- Only masses with `dateTime` within this range are loaded
+
+### Cascade effects:
+When a volunteer is removed:
+- Removed from all ministry `py volunteers` and `py subs` dicts
+- Removed from family cross-references (`py family_members` lists of other volunteers)
+
+When a service is removed:
+- Removed from ministry `py services` dicts
+- Associated masses that reference this service are NOT removed (they may still be relevant as one-time overrides)
+
+---
+
+## 8. Email & Phone Normalization
+
+All email addresses are normalized to lowercase. Comma-separated multi-value fields are split into Python lists:
+
+- Volunteer `email` → `py emails` (list of strings, lowercased)
+- Volunteer `cell` → `py cells` (list of strings)
+- Volunteer `phone` → `py phones` (list of strings)
+
+Empty or null source fields result in empty lists (not `None`), ensuring callers can always iterate without null checks.
+
+---
+
+## 9. MSP Family Cross-Linking
+
+Volunteers sharing the same `familyId` are grouped together:
+
+- Each volunteer receives a `py family_members` list containing the other volunteer dicts in the same family (excluding self)
+- Volunteers with `familyId` of `None` or missing get an empty `py family_members` list
+- Family binding flags (`bindPhoneAndAddress`, `bindEmail`, `bindServicePreferences`) are preserved on the volunteer dict but not acted upon by MSP.py
+
+---
+
+## 10. Error Handling
+
+- Critical failures (authentication errors, malformed API responses) call `exit(1)` with a log message, matching ParishSoftv2's pattern
+- HTTP 400 errors on write operations log the error and return `None`
+- HTTP 401 errors call `exit(1)` — indicates invalid API key
+- HTTP 500 errors are retried via the session retry policy; if all retries fail, `exit(1)` is called
+
+---
+
+## 11. Dependencies
+
+- `requests` + `urllib3` — HTTP client with retry logic
+- `ECC` — imported for logging setup (used by callers)
+- Standard library: `os`, `re`, `sys`, `json`, `time`, `datetime`
+
+---
+
+## 12. MSP API Data Model Reference
+
+### 12.1 Volunteer Properties (from API)
+
+| Property | Type | Notes |
+|----------|------|-------|
+| `id` | string/int | Read-only |
+| `firstName` | string | Required |
+| `lastName` | string | Required unless `isGroup=True` |
+| `title` | string | Optional (e.g., "Sr.") |
+| `isGroup` | boolean | Group volunteers fill multiple positions |
+| `contactName` | string | For group volunteers only |
+| `familyId` | string/null | Family association |
+| `email` | string | Comma-separated addresses |
+| `emailUnlisted` | boolean | |
+| `cell` | string | Comma-separated mobile numbers |
+| `cellUnlisted` | boolean | |
+| `phone` | string | Land-line numbers |
+| `phoneUnlisted` | boolean | |
+| `address` | string | Newline-separated mailing address |
+| `ministries` | hash | Ministry ID → qualification (`"NONE"`, `"SUB"`, or title ID) |
+| `servicePreferences` | array | Ordered preference objects |
+| `cantServeTimes` | array | Unavailability blocks |
+| `inactive` | boolean | Prevents scheduling |
+| `substitute` | boolean | Read-only. True if SUB in all ministries |
+| `preassignmentsOnly` | boolean | Manual/preassigned only |
+| `scheduledDuties` | hash | By schedule ID, arrays of assignment records |
+| `externalId` | string | External system identifier (used for PS linkage) |
+| `dateCreated` | string | UTC timestamp (read-only) |
+| `dateModified` | string | UTC timestamp (read-only) |
+| `comments` | string | Free-form reference text |
+| `customFieldValues` | hash | Custom field ID → value |
+
+### 12.2 Mass Properties (from API)
+
+| Property | Type | Notes |
+|----------|------|-------|
+| `id` | string | Composite: `scheduleId_localMassId` (read-only) |
+| `description` | string | Optional |
+| `serviceId` | string/null | Parent service, null if one-time |
+| `dateTime` | string | Local timezone `YYYY-MM-DD HH:MM:SS` |
+| `positions` | hash | Ministry ID → array of position assignments |
+| `titleRules` | array | Title requirements per ministry |
+| `openMinistries` | hash | Read-only: open positions per ministry |
+| `kioskCheckins` | array | Check-in records |
+| `kioskState` | string | Read-only: `inactive|active|reconciled` |
+| `dontAutoSchedule` | boolean | |
+| `overload` | boolean | |
+| `choirs` | array | Choir ministry IDs |
+
+### 12.3 Ministry Properties (from API)
+
+| Property | Type | Notes |
+|----------|------|-------|
+| `id` | string/int | Read-only |
+| `name` | string | Read-only |
+| `description` | string | Optional |
+| `order` | int | Read-only global position |
+| `volunteers` | hash | Volunteer ID → qualification |
+| `ministryGroupId` | string | Parent group ID |
+| `numberAssignments` | boolean | Enable position numbering |
+| `assignmentNumberLabels` | array | Custom position labels |
+| `neverSplitFamilies` | boolean | |
+| `blockSchedulingPattern` | string/null | `oneWeek|twoWeek|oneMonth` |
+| `scheduleAutonomously` | boolean | |
+| `choir` | boolean | |
+| `compatibleMinistries` | hash | Ministry ID → combination rule |
+| `rosterCode` | string | Short-hand identifier |
+| `autoQualifyNewVolunteers` | boolean | |
+
+### 12.4 Service Properties (from API)
+
+| Property | Type | Notes |
+|----------|------|-------|
+| `id` | string/int | Read-only |
+| `name` | string | |
+| `label` | string | Read-only calculated display label |
+| `description` | string | Optional location/details |
+| `type` | string | `Weekly|Monthly|Yearly` |
+| `inactive` | boolean | |
+| `requiredMinistries` | hash | Ministry ID → position count |
+| `timeOffset` | hash | Recurrence pattern definition |
+| `titleRules` | array | Title requirements |
+| `choirs` | array | Choir ministry IDs |
+
+---
+
+## 13. Reconciliation Summary
+
+**Created**: 2026-03-01
+**API docs cross-referenced**: 2026-03-01 (MSP REST API v2 reference)
+
+This document was created based on requirements gathering with the project owner and cross-referencing the MSP REST API v2 documentation. The specification follows the same structural conventions as the ParishSoftv2 module specification.

--- a/specs/parishsoftv2/spec.md
+++ b/specs/parishsoftv2/spec.md
@@ -1,0 +1,387 @@
+# ParishSoftv2 Module Specification
+
+**Module**: `python/ParishSoftv2.py`
+**Purpose**: Helper module for applications that interact with the ParishSoft Family Suite v2 cloud API. Loads, caches, cross-links, and filters parish data (families, members, workgroups, ministries, contributions).
+
+---
+
+## 1. Overview
+
+ParishSoftv2 is a data-access layer that:
+
+1. Authenticates with the ParishSoft v2 REST API using an API key
+2. Downloads parish data via paginated GET/POST endpoints
+3. Caches responses as JSON files to avoid redundant API calls
+4. Cross-links families, members, workgroups, ministries, and contributions into an interconnected in-memory data model
+5. Filters the data based on active status, parishioner status, and deceased status
+6. Exposes public query functions for common operations (email lookup, phone lookup, salutations, etc.)
+
+**API Base URL**: `https://ps-fs-external-api-prod.azurewebsites.net/api/v2`
+
+---
+
+## 2. Public API
+
+### 2.1 `load_families_and_members()`
+
+**Primary entry point.** Downloads all parish data, cross-links it, filters it, and returns five dictionaries.
+
+```python
+def load_families_and_members(
+    api_key=None,              # Required. ParishSoft API key
+    active_only=True,          # Filter out inactive families/members
+    parishioners_only=True,    # Filter to registered org members only
+    load_contributions=False,  # False, True (last year), or date string
+    include_deceased=False,    # Include deceased members
+    log=None,                  # Logger instance
+    cache_dir="ps-data",       # Directory for cache files
+    expected_org='Epiphany Catholic Church',  # Org name sanity check
+    cache_limit="14m",         # Cache freshness ("14m", "1d", "24s", "7h")
+) -> tuple:
+```
+
+**Returns**: `(families, members, family_workgroup_memberships, member_workgroup_memberships, ministry_type_memberships)`
+
+- `families`: `dict[int, dict]` keyed by Family DUID
+- `members`: `dict[int, dict]` keyed by Member DUID
+- `family_workgroup_memberships`: `dict[int, dict]` keyed by Family Workgroup DUID
+- `member_workgroup_memberships`: `dict[int, dict]` keyed by Member Workgroup DUID
+- `ministry_type_memberships`: `dict[int, dict]` keyed by Ministry Type ID
+
+**Load sequence**:
+
+1. Parse `cache_limit` and set global cache freshness threshold
+2. Create `cache_dir` if it doesn't exist
+3. Set up HTTP session with API key header and retry logic (3 retries, 0.2s backoff)
+4. Verify organization (POST `organizations/search`, expect exactly one matching `expected_org`)
+5. Optionally load financial data: funds, pledges, contributions
+6. Load family data: families, family groups, family workgroups + memberships
+7. Load member data: members, statuses, types, contact info, workgroups + memberships
+8. Load ministry data: ministry types + memberships
+9. Save all accumulated keyed caches
+10. Cross-link all data (see Section 4)
+11. Filter data per `active_only`, `parishioners_only`, `include_deceased`
+12. Return the five dictionaries
+
+### 2.2 Family Query Functions
+
+#### `family_is_active(family) -> bool`
+
+A family is active if:
+- It is NOT in the "Inactive" family group, AND
+- At least one member is active (via `member_is_active`)
+
+Returns `False` if all members are deceased/inactive or no members exist.
+
+#### `family_is_parishioner(family, org_id=None) -> bool`
+
+Returns `True` if the family's `registeredOrganizationID` matches the org ID. Uses the global `_org_id` if `org_id` is not provided.
+
+#### `get_family_heads(family) -> dict`
+
+Returns a dict of members (keyed by member DUID) whose `memberType` is one of: `Head`, `Husband`, `Wife`.
+
+#### `family_business_logistics_emails(family, member_workgroups, log) -> list[str]`
+
+Returns a list of email addresses for sending business logistics communications. Uses a 4-tier fallback:
+
+1. Members of the family who are in the "Business Logistics Email" member workgroup
+2. Members with Head/Husband/Wife role
+3. All family members with email addresses
+4. The family-level email address
+
+#### `family_business_logistics_emails_members(family, member_workgroups, log) -> list[dict]`
+
+Same logic as above but returns the member objects instead of email strings.
+
+### 2.3 Member Query Functions
+
+#### `member_is_deceased(member) -> bool`
+
+Returns `True` if `memberStatus` is `"Deceased"`.
+
+#### `member_is_active(member) -> bool`
+
+Returns `True` unless `memberStatus` is `"Inactive"` or `"Deceased"`.
+
+#### `get_member_public_phones(member) -> list[dict]`
+
+Returns a list of `{'number': str, 'type': str}` dicts for mobile and home phones, but only if `family_PublishPhone` is truthy. Types are `"cell"` and `"home"`.
+
+#### `get_member_private_phones(member)`
+
+**Stub** - not implemented (body is `pass`).
+
+#### `get_member_public_email(member) -> str | None`
+
+Returns the first email from `py emailAddresses` if `family_PublishEMail` is truthy. Returns `None` otherwise.
+
+#### `get_member_preferred_first(member) -> str`
+
+Returns the member's nickname (from `py contactInfo.nickName`) if available, otherwise `firstName`.
+
+### 2.4 Salutation Function
+
+#### `salutation_for_members(members) -> tuple[str, str]`
+
+Returns `(first_part, last_name)` for addressing a group of members.
+
+**Rules**:
+- 1 member: `("PreferredFirst", "Last")`
+- 2 members, same last name: `("First1 and First2", "Last")`
+- 3+ members, same last name: `("First1, First2, and First3", "Last")`
+- 2 members, different last names: `("First1 Last1 and First2", "Last2")`
+- 3+ members, different last names: `("First1 Last1, First2 Last2, and First3", "Last3")`
+
+---
+
+## 3. Caching System
+
+### 3.1 Cache Limit
+
+The `cache_limit` parameter accepts humanized time strings:
+- `s` = seconds, `m` = minutes, `h` = hours, `d` = days
+- Examples: `"24s"`, `"15m"`, `"7h"`, `"2d"`
+- Default: `"14m"` (designed for 15-minute cron intervals)
+
+Cache files older than the limit are re-fetched from the API.
+
+**Note**: There is a hardcoded debug override at module level that sets the cache limit to 1 day. The `cache_limit` parameter in `load_families_and_members` overrides this.
+
+### 3.2 Simple Cache
+
+Files stored as `cache-v2-{endpoint}.json` (with `/` replaced by `-`) in `cache_dir`.
+
+- `_save_cache(endpoint, elements, cache_dir, log)`: Writes elements as JSON
+- `_load_cache(endpoint, cache_dir, log)`: Returns elements if file exists and is fresh, else `None`
+
+### 3.3 Keyed Cache
+
+For endpoints that return per-key data (e.g., workgroup membership per workgroup ID). Multiple keys share a single JSON file.
+
+- `_save_keyed_cache()`: Stores in-memory; actual file write deferred
+- `_load_keyed_cache()`: Loads entire file on first access, then reads from memory
+- `_save_all_keyed_caches()`: Writes all accumulated keyed caches to disk at end of load
+
+**Known issue**: `json.dump()` converts integer keys to strings; `_load_keyed_cache` compensates by casting the lookup key to `str`.
+
+---
+
+## 4. Data Cross-Linking
+
+After loading, the following cross-references are created (all prefixed with `py ` to distinguish from raw API fields):
+
+### Family enrichments:
+- `py members`: list of member dicts in this family
+- `py family group`: string name of the family group (e.g., "Inactive")
+- `py workgroups`: dict of family workgroup memberships keyed by workgroup name
+- `py pledges`: list of pledge dicts
+- `py contributions`: list of contribution dicts
+- `py emailAddresses` (via `eMailAddress`): list of emails split on `;`
+
+### Member enrichments:
+- `py family`: back-reference to the containing family dict
+- `py contactInfo`: contact info dict (includes `nickName`)
+- `py workgroups`: dict of member workgroup memberships keyed by workgroup name
+- `py ministries`: dict of current ministry memberships keyed by ministry name
+- `py emailAddresses` (via `emailAddress`): list of emails split on `;`
+- `py friendly name FL`: "First Last" using nickname if available
+- `py friendly name LF`: "Last, First" using nickname if available
+- `py active`: boolean, set during filtering
+
+### Workgroup/Ministry membership enrichments:
+- `py member duid`: back-reference to the member
+- `py family duid`: back-reference to the family
+
+---
+
+## 5. Filtering
+
+Filtering happens after all cross-linking is complete. Controlled by three flags:
+
+### Member filtering:
+- `active_only=True`: removes members where `member_is_active()` returns `False`
+- `include_deceased=False`: removes deceased members
+
+### Family filtering:
+- `active_only=True`: removes families where `family_is_active()` returns `False`
+- `parishioners_only=True`: removes families where `family_is_parishioner()` returns `False`
+- Families with no remaining active members are removed
+
+### Cascade deletions:
+When a member is removed:
+- Removed from all member workgroup memberships
+- Removed from all ministry type memberships
+- Removed from their family's `py members` list
+- Removed from the members dict
+
+When a family is removed:
+- Removed from all family workgroup memberships
+- Removed from all ministry type memberships
+- All remaining members in the family are removed from the members dict
+- Removed from the families dict
+
+---
+
+## 6. API Interaction
+
+### 6.1 HTTP Session
+
+- Uses `requests.Session` with `x-api-key` header
+- Retry policy: 3 retries, 0.2s backoff factor, allowed on POST and GET
+- All requests use `Accept: application/json` and `Content-Type: application/json`
+
+### 6.2 Endpoint Types
+
+| Function | Method | Pagination |
+|----------|--------|------------|
+| `_get_endpoint` | GET | No |
+| `_get_paginated_endpoint` | GET | Yes |
+| `_post_endpoint` | POST | No |
+| `_post_paginated_endpoint` | POST | Yes |
+
+### 6.3 Pagination
+
+Two offset types supported:
+- `index`: offset = number of elements already fetched
+- `page`: offset = page number (1-based)
+
+Two response formats handled:
+- **List**: empty list signals end of data
+- **Dict**: contains `pagingInfo.pageNumber` and `pagingInfo.totalPages`
+
+Default page size is 100; some endpoints use 500 (contributions, pledges, members).
+
+### 6.4 Endpoints Used
+
+| Endpoint | Method | Pagination | Data |
+|----------|--------|------------|------|
+| `organizations/search` | POST | No | Organization lookup |
+| `offering/{org_id}/funds` | GET | No | Fund definitions |
+| `offering/pledge/list` | GET | Page (500) | Pledges |
+| `offering/contributiondetail/list` | GET | Page (500) | Contributions |
+| `families/search` | POST | Page (100) | Family records |
+| `families/group/lookup/list` | GET | No | Family group lookups |
+| `families/workgroup/list` | GET | Page (100) | Family workgroups |
+| `families/workgroup/{duid}/list` | GET | Page (100) | Family workgroup members |
+| `members/search` | POST | Page (100) | Member records |
+| `members/memberstatus/list` | GET | No | Member status lookups |
+| `members/membertype/list` | GET | No | Member type lookups |
+| `members/contact/list` | POST | Page (100) | Member contact info |
+| `members/workgroup/lookup/list` | GET | Page (100) | Member workgroup lookups |
+| `members/workgroup/{duid}/list` | GET | Page (100) | Member workgroup members |
+| `ministry/type/list` | GET | Page (100) | Ministry type lookups |
+| `ministry/{id}/minister/list` | GET | Page (100) | Ministry members |
+
+### 6.5 Cross-Reference with REST API Documentation
+
+**Source**: Swagger/OpenAPI spec at `https://ps-fs-external-api-prod.azurewebsites.net/swagger/v2/swagger.json`
+
+#### Endpoints: Code vs API Documentation
+
+| Endpoint (code) | API Doc Match | Discrepancies |
+|---|---|---|
+| `organizations/search` (POST) | **NOT IN SWAGGER** | Endpoint is not documented in the v2 OpenAPI spec. May be undocumented or from an earlier API version. |
+| `offering/{org_id}/funds` (GET) | `/api/v2/offering/{organizationId}/funds` | Matches. No pagination needed. |
+| `offering/pledge/list` (GET) | `/api/v2/offering/pledge/list` | Matches. API uses `PageSize`/`PageNumber`; code correctly uses these names with limit=500. |
+| `offering/contributiondetail/list` (GET) | `/api/v2/offering/contributiondetail/list` | Matches. Code passes `startDate` (camelCase) as query param; API documents `StartDate` (PascalCase) — works because server is case-insensitive. API also supports `EndDate`, `FundId`, `FamilyId`, `MemberId`, `StartAmount`, `GivingSourceId`, `OrganizationId` filters that the code does not use. |
+| `families/search` (POST) | `/api/v2/families/search` | **Pagination mismatch**: API returns `Array of FamilySearchResponseDto` (a simple list with no pagingInfo). Code uses `_post_paginated_endpoint` with `PageNumber`/page offset, paging via empty-array detection. The body param `organizationIDs` is not documented in swagger but works. |
+| `families/group/lookup/list` (GET) | `/api/v2/families/group/lookup/list` | Matches. No pagination. |
+| `families/workgroup/list` (GET) | `/api/v2/families/workgroup/list` | **Page size**: API allows max 500 (default 500) with `PageSize`/`PageNumber`. Code uses default limit=100. Could use 500 for fewer round-trips. |
+| `families/workgroup/{duid}/list` (GET) | `/api/v2/families/workgroup/{workGroupId}/list` | **Page size**: API allows max 500. Code uses default limit=100. API response type is `ListPagingResponse` (dict with `pagingInfo`+`data`); code handles both list and dict formats in `_get_paginated_endpoint`. |
+| `members/search` (POST) | `/api/v2/members/search` | **Pagination param mismatch**: Code uses `maximumRows`/`startRowIndex` (non-standard names), while swagger shows no explicit pagination params for this endpoint. These are passed in the POST body. API returns a simple array. |
+| `members/memberstatus/list` (GET) | `/api/v2/members/memberstatus/list` | Matches. No pagination. |
+| `members/membertype/list` (GET) | `/api/v2/members/membertype/list` | Matches. Returns array of strings. |
+| `members/contact/list` (POST) | `/api/v2/members/contact/list` | Matches. Code uses default `Offset`/`Limit` param names with page-type offset. |
+| `members/workgroup/lookup/list` (GET) | `/api/v2/members/workgroup/lookup/list` | **Page size**: API allows max 500 with `PageSize`/`PageNumber`. Code uses default limit=100. API response is `ListPagingResponse` type. Also supports optional `organizationId` query param that code doesn't use. |
+| `members/workgroup/{duid}/list` (GET) | `/api/v2/members/workgroup/{workGroupId}/list` | **Page size**: API allows max 500. Code uses default limit=100. API response is `ListPagingResponse` type. |
+| `ministry/type/list` (GET) | `/api/v2/ministry/type/list` | **Page size**: API allows max 500 with `PageSize`/`PageNumber`. Code uses default limit=100. Also supports optional `organizationId` query param that code doesn't use. |
+| `ministry/{id}/minister/list` (GET) | `/api/v2/ministry/{ministryTypeId}/minister/list` | **Page size**: API allows max 500. Code uses default limit=100. |
+
+#### API Endpoints NOT Used by Code
+
+The following v2 API endpoints exist but are not used by `ParishSoftv2.py`:
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `constituents/search` | GET | Constituent search (separate from Family/Member model) |
+| `constituents/detail/{sDioceseId}` | GET | Constituent detail lookup |
+| `families/quick-search` | POST | Faster family search |
+| `families/{familyId}` | GET | Single family detail |
+| `families/{familyId}/member/list` | GET | Members of a specific family |
+| `families/{familyId}/ministry/list` | GET | Ministries of a specific family |
+| `families/{familyId}/contact` | PUT | Update family contact info |
+| `families/{familyId}/autofill` | PUT | Update family autofill fields |
+| `families/change/list` | GET | Family change log by date range |
+| `members/quick-search` | POST | Faster member search |
+| `members/{memberId}` | GET | Single member detail |
+| `members/{memberId}/sacrament/{type}/list` | GET | Member sacrament records |
+| `members/workgroup/list` | GET | **Deprecated** member workgroup list |
+| `members/{memberId}/contact` | PUT | Update member contact info |
+| `offering/{organizationId}/givers` | GET | Giver list |
+| `offering/{organizationId}/contribution/summary/list` | POST | Family contribution summary |
+
+#### Key Observations
+
+1. **`organizations/search` is undocumented** — this endpoint is not in the swagger spec but is used as the first call to identify the org ID. It may be an older endpoint carried forward.
+
+2. **Page size opportunity** — 8 endpoints use `limit=100` where the API allows `PageSize` up to 500. Increasing to 500 would reduce API round-trips by up to 5x for large datasets (e.g., ministry types, workgroup memberships).
+
+3. **`members/search` uses non-standard pagination params** — `maximumRows`/`startRowIndex` are not in the swagger docs. These may be legacy body params that the API still accepts but doesn't document.
+
+4. **`contributiondetail/list` has unused filters** — the API supports filtering by `EndDate`, `FundId`, `FamilyId`, `MemberId`, `StartAmount`, `GivingSourceId`, and `OrganizationId` that the code doesn't expose.
+
+5. **Response format ambiguity** — some endpoints return `ListPagingResponse` (dict with `pagingInfo` and `data`) while others return plain arrays. The code's `_get_paginated_endpoint` handles both formats, which is correct.
+
+6. **No write operations** — the code only reads data. The API offers PUT endpoints for updating family and member contact info that are not used.
+
+---
+
+## 7. Ministry Filtering
+
+Ministry types are filtered by an allowlist during loading. Only types matching these patterns are retained:
+- Names starting with three digits followed by `-` (e.g., `"100-Lectors"`)
+- Specifically named: `"E-Soul Life"` or `"E-Taize Prayer"`
+
+Ministry membership records are further filtered to only include records that are current (today falls between `startDate` and `endDate`).
+
+---
+
+## 8. Date Normalization
+
+All date fields from the API are converted from ISO format strings to `datetime.date` objects using `_normalize_dates()`. Fields normalized include:
+- Pledges: `pledgeDate`, `pledgeStartDate`
+- Contributions: `contributionDate`
+- Families: `dateModified`
+- Members: `birthdate`, `dateModified`, `dateOfDeath`
+- Member contact info: `dateOfBirth`, `dateOfDeath`
+- Ministry memberships: `startDate`, `endDate`
+
+---
+
+## 9. Email Normalization
+
+All email addresses are normalized to lowercase. Multi-valued email fields (separated by `;`) are split into Python lists stored in `py` prefixed keys:
+- Family: `eMailAddress` → `py eMailAddresses` (list)
+- Member: `emailAddress` → `py emailAddresses` (list)
+- Family workgroup members: `email` → `py emails` (list)
+- Member workgroup members: `emailAddress` → `py emailAddresses` (list)
+
+---
+
+## 10. Dependencies
+
+- `requests` + `urllib3` — HTTP client with retry logic
+- `ECC` — imported but not directly used by public functions (used by callers for logging setup)
+- Standard library: `os`, `re`, `sys`, `csv`, `json`, `time`, `datetime`
+
+---
+
+## 11. Reconciliation Summary
+
+**Reconciled**: 2026-03-01
+**API docs cross-referenced**: 2026-03-01 (swagger v2 spec)
+
+This document was created to reflect the actual implementation of `python/ParishSoftv2.py`.
+The specification was derived from reading the source code, analyzing usage across 14 consumer scripts,
+and cross-referencing against the ParishSoft v2 OpenAPI/Swagger specification.

--- a/specs/sync-ps-to-cc/constantcontact-py-update-tasks.md
+++ b/specs/sync-ps-to-cc/constantcontact-py-update-tasks.md
@@ -1,0 +1,109 @@
+# ConstantContact.py Update Tasks
+
+Tasks to update `python/ConstantContact.py` to match the planned changes
+in `specs/constantcontact/spec.md` (sections 2.2, 6, 7, 10).
+
+## Phase 1: Foundation
+
+These must be completed first; all other tasks depend on them.
+
+- [ ] **1.1 Add imports for retry/adapter**
+  Add `from urllib3.util.retry import Retry` and
+  `from requests.adapters import HTTPAdapter` to the imports section
+  (after `import requests`).
+
+- [ ] **1.2 Define CCAPIError exception class**
+  Add a `CCAPIError` exception class after the imports (before the
+  first `####` section divider). Per the spec (Section 2.2):
+  - Attributes: `status_code` (int), `response_text` (str),
+    `endpoint` (str)
+  - Inherits from `Exception`
+  - `__str__` should include the endpoint and status code for
+    readable error messages
+
+## Phase 2: Retry and Rate Limit Infrastructure
+
+Depends on: Phase 1
+
+- [ ] **2.1 Create a module-level session factory**
+  Add a helper function (e.g., `_create_session()`) that creates a
+  `requests.Session` with an `HTTPAdapter` configured with
+  `urllib3.util.Retry`:
+  - `total=3` retries
+  - `backoff_factor=0.2`
+  - `status_forcelist=[429]` (retry on rate limit)
+  - `respect_retry_after_header=True` (honor Retry-After from 429s)
+  - Mount the adapter on both `https://` and `http://`
+  - Return the configured session
+
+  This avoids duplicating session setup in every API function.
+  The `allowed_methods` parameter should be set by the caller or
+  default to `["GET", "PUT", "POST"]`.
+
+## Phase 3: Update API Functions
+
+Depends on: Phase 2
+
+- [ ] **3.1 Update `api_get_all()` to use session and raise CCAPIError**
+  - Replace `requests.get(url, ...)` with `session.get(url, ...)`
+    using a session from `_create_session()`
+  - Replace `exit(1)` (lines 56-58) with
+    `raise CCAPIError(r.status_code, r.text, api_endpoint)`
+  - Remove the `# JMS Need to surround this in a retry` comment
+    (the retry is now implemented)
+
+- [ ] **3.2 Update `_api_put_or_post()` to use session and raise CCAPIError**
+  - The current design passes `requests.put` or `requests.post` as
+    `action_fn`. This won't work with a session object. Refactor to
+    use `action_name` (the string "PUT" or "POST") to select
+    `session.put` or `session.post` instead of accepting a function
+    reference.
+  - Replace `exit(1)` (lines 87-90) with
+    `raise CCAPIError(r.status_code, r.text, api_endpoint)`
+  - Update callers `api_put()` and `api_post()` accordingly (they
+    currently pass `requests.put`/`requests.post` as the first arg).
+
+## Phase 4: Backward Compatibility
+
+Depends on: Phase 3
+
+- [ ] **4.1 Update `sync-constant-contact.py` for CCAPIError**
+  Add `try`/`except CCAPIError` around all CC API calls in
+  `media/linux/ps-queries/sync-constant-contact.py` to preserve its
+  current behavior:
+  - `CC.api_get_all()` calls (lines 1024, 1031, 1038): catch
+    `CCAPIError`, log the error, and `exit(1)` — same as the old
+    behavior.
+  - `CC.create_or_update_contact()` (line 741): catch, log, exit(1).
+  - `CC.update_contact_full()` (line 759): catch, log, exit(1).
+  - Import `CCAPIError` from `ConstantContact` at the top of the
+    script (e.g., `from ConstantContact import CCAPIError`).
+
+## Phase 5: Verification
+
+Depends on: Phase 4
+
+- [ ] **5.1 Verify no remaining `exit(1)` in API functions**
+  Confirm that `api_get_all`, `_api_put_or_post`, `api_put`, and
+  `api_post` no longer call `exit(1)`. The only `exit(1)` calls
+  remaining in ConstantContact.py should be in `get_access_token()`
+  (for authentication failures, which are not API operation errors).
+
+- [ ] **5.2 Verify old script still functions**
+  Confirm that `sync-constant-contact.py` handles `CCAPIError` in
+  all code paths that previously relied on `exit(1)`.
+
+## Notes
+
+- The `get_access_token()` function has two `exit(1)` calls (lines
+  291-294, 301-304) for authentication failures. These are NOT
+  changed because they are not API operation errors — they indicate
+  the script cannot proceed at all (no token, or token not yet valid).
+  The spec says "error and exit" for these cases.
+
+- The `oauth2_device_flow_refresh()` function already returns `None`
+  on error instead of calling `exit(1)`, so no change is needed there.
+
+- The session/retry changes do not alter function signatures or return
+  types, so they are backward-compatible. Only the error handling
+  change (exit → exception) affects callers.

--- a/specs/sync-ps-to-cc/constantcontact-py-update-tasks.md
+++ b/specs/sync-ps-to-cc/constantcontact-py-update-tasks.md
@@ -7,12 +7,12 @@ in `specs/constantcontact/spec.md` (sections 2.2, 6, 7, 10).
 
 These must be completed first; all other tasks depend on them.
 
-- [ ] **1.1 Add imports for retry/adapter**
+- [x] **1.1 Add imports for retry/adapter**
   Add `from urllib3.util.retry import Retry` and
   `from requests.adapters import HTTPAdapter` to the imports section
   (after `import requests`).
 
-- [ ] **1.2 Define CCAPIError exception class**
+- [x] **1.2 Define CCAPIError exception class**
   Add a `CCAPIError` exception class after the imports (before the
   first `####` section divider). Per the spec (Section 2.2):
   - Attributes: `status_code` (int), `response_text` (str),
@@ -25,7 +25,7 @@ These must be completed first; all other tasks depend on them.
 
 Depends on: Phase 1
 
-- [ ] **2.1 Create a module-level session factory**
+- [x] **2.1 Create a module-level session factory**
   Add a helper function (e.g., `_create_session()`) that creates a
   `requests.Session` with an `HTTPAdapter` configured with
   `urllib3.util.Retry`:
@@ -44,7 +44,7 @@ Depends on: Phase 1
 
 Depends on: Phase 2
 
-- [ ] **3.1 Update `api_get_all()` to use session and raise CCAPIError**
+- [x] **3.1 Update `api_get_all()` to use session and raise CCAPIError**
   - Replace `requests.get(url, ...)` with `session.get(url, ...)`
     using a session from `_create_session()`
   - Replace `exit(1)` (lines 56-58) with
@@ -52,7 +52,7 @@ Depends on: Phase 2
   - Remove the `# JMS Need to surround this in a retry` comment
     (the retry is now implemented)
 
-- [ ] **3.2 Update `_api_put_or_post()` to use session and raise CCAPIError**
+- [x] **3.2 Update `_api_put_or_post()` to use session and raise CCAPIError**
   - The current design passes `requests.put` or `requests.post` as
     `action_fn`. This won't work with a session object. Refactor to
     use `action_name` (the string "PUT" or "POST") to select
@@ -67,7 +67,7 @@ Depends on: Phase 2
 
 Depends on: Phase 3
 
-- [ ] **4.1 Update `sync-constant-contact.py` for CCAPIError**
+- [x] **4.1 Update `sync-constant-contact.py` for CCAPIError**
   Add `try`/`except CCAPIError` around all CC API calls in
   `media/linux/ps-queries/sync-constant-contact.py` to preserve its
   current behavior:
@@ -83,13 +83,13 @@ Depends on: Phase 3
 
 Depends on: Phase 4
 
-- [ ] **5.1 Verify no remaining `exit(1)` in API functions**
+- [x] **5.1 Verify no remaining `exit(1)` in API functions**
   Confirm that `api_get_all`, `_api_put_or_post`, `api_put`, and
   `api_post` no longer call `exit(1)`. The only `exit(1)` calls
   remaining in ConstantContact.py should be in `get_access_token()`
   (for authentication failures, which are not API operation errors).
 
-- [ ] **5.2 Verify old script still functions**
+- [x] **5.2 Verify old script still functions**
   Confirm that `sync-constant-contact.py` handles `CCAPIError` in
   all code paths that previously relied on `exit(1)`.
 

--- a/specs/sync-ps-to-cc/spec.md
+++ b/specs/sync-ps-to-cc/spec.md
@@ -303,15 +303,19 @@ Subject: Constant Contact sync update: {CC List Name}
 
 Body:
   1. Header with CC List name and timestamp
-  2. Summary counts (contacts created, subscribed, unsubscribed, failures)
-  3. Table of actions performed (action type, contact email, contact name)
-  4. Section: "Manually Unsubscribed Contacts"
-     - Contacts globally unsubscribed from CC (permission_to_send = 'unsubscribed')
-       who have PS Members in this sync's workgroup
-     - Table: email, PS Member name(s), PS Member DUID(s)
-  5. Section: "Contacts Removed from List (in ParishSoft)"
-     - Contacts removed from this specific CC List by this sync run
-     - Table: email, contact name, reason
+  2. ParishSoft Member Workgroup name and Constant Contact List name
+  3. Summary counts (contacts subscribed, contacts unsubscribed, update failures)
+  4. "Actions Performed" table grouped by action type (subscribe, unsubscribe)
+     with blue separator rows between groups; sorted by last name then first
+     name within each group
+     - Columns: Action, Contact Name(s), ParishSoft Member DUID(s), Email
+     - "create" and "update_name" actions are suppressed from this table
+       (create actions always have a corresponding subscribe action;
+       name updates are logged but not emailed)
+  5. "Failed Actions" section (only if failures occurred)
+     - Columns: Contact Name(s), ParishSoft Member DUID(s), Email, Action,
+       Update error
+     - Sorted by last name then first name
   6. Footer noting this is an automated message
 ```
 
@@ -319,13 +323,15 @@ Body:
 
 - Clean, professional HTML suitable for email clients
 - Use inline CSS (email clients strip `<style>` blocks)
-- Tables with borders, alternating row colors for readability
+- Tables: auto-width (sized to content), left-justified, bordered, alternating row colors for readability
+- Table column headings: centered, blue background (`#4472C4`) with white text
+- Table cells: `white-space: nowrap` to prevent wrapping
 - Clear section headings
 - No images or external resources (for email deliverability)
 
 ### 5.3 Failed Actions
 
-If any individual contact updates failed during execution, include a "Failed Actions" section in the email listing the contact email, intended action, and error message.
+If any individual contact updates failed during execution, include a "Failed Actions" section (with red heading) listing: Contact Name(s), ParishSoft Member DUID(s), Email, Action, and Update error. Sorted by last name then first name.
 
 ### 5.4 Unsubscribed-Contacts Report Email
 
@@ -338,14 +344,16 @@ Body:
   1. Header with CC List name and timestamp
   2. Explanation paragraph:
      "The following ParishSoft Members are in the '{PS Workgroup Name}'
-     workgroup but have manually unsubscribed from Constant Contact.
-     They should be removed from the '{PS Workgroup Name}' workgroup
-     in ParishSoft."
-  3. Table: PS Member name(s), PS Member DUID(s), email address
-  4. Footer noting this is an automated message
+     workgroup but have manually unsubscribed from Constant Contact."
+  3. Bold red warning paragraph (16px):
+     "These ParishSoft Members should be removed from the
+     '{PS Workgroup Name}' workgroup in ParishSoft."
+  4. Table: PS Member name(s), PS Member DUID(s), email address
+     - Sorted by last name then first name
+  5. Footer noting this is an automated message
 ```
 
-Follows the same styling guidelines as Section 5.2 (inline CSS, bordered tables with alternating row colors, no images).
+Follows the same styling guidelines as Section 5.2 (inline CSS, bordered tables with alternating row colors, auto-width, no images).
 
 ---
 

--- a/specs/sync-ps-to-cc/spec.md
+++ b/specs/sync-ps-to-cc/spec.md
@@ -1,0 +1,484 @@
+# sync-ps-to-cc.py Specification
+
+**Script**: `media/linux/ps-queries/sync-ps-to-cc.py`
+**Purpose**: Synchronize ParishSoft Member Workgroups to Constant Contact Lists. PS is the source of truth; CC data is updated to match.
+
+---
+
+## 1. Overview
+
+This script replaces `sync-constant-contact.py` with a cleaner, more robust implementation. It:
+
+1. Loads active PS Members (including non-parishioners)
+2. Downloads CC Contacts and Lists
+3. Correlates PS Members to CC Contacts by email address
+4. Computes a de-duplicated set of sync actions (create, subscribe, unsubscribe, delete candidates)
+5. Executes those actions against the CC API (with retry and rate-limit handling)
+6. Sends per-list HTML notification emails detailing the actions performed
+7. Supports a dry-run mode that logs actions without executing them
+
+**Key design principles**:
+
+- Multiple PS Members may share a single email address and therefore map to a single CC Contact. All logic must handle this correctly.
+- Downloaded data (CC contacts, PS members) is treated as **read-only** after loading and indexing. Sync logic produces an **action list** — a separate list of dicts describing what needs to happen — rather than mutating contact data in place. The action list is the single source of truth for execution, dry-run logging, and notification emails.
+
+---
+
+## 2. Synchronization Configuration
+
+### 2.1 Config Module
+
+The synchronization mappings are extracted to a standalone Python module that can be imported by multiple scripts.
+
+**File**: `media/linux/ps-queries/cc_sync_config.py`
+
+```python
+SYNCHRONIZATIONS = [
+    {
+        'source ps member wg': 'Daily Gospel Reflections',
+        'target cc list':      'SYNC Daily Gospel Reflections',
+        'notifications':       [
+            'ps-constantcontact-sync@epiphanycatholicchurch.org,'
+            'director-communications@epiphanycatholicchurch.org',
+        ],
+    },
+    {
+        'source ps member wg': 'Parish-wide Email',
+        'target cc list':      'SYNC Parish-wide Email',
+        'notifications':       [
+            'ps-constantcontact-sync@epiphanycatholicchurch.org,'
+            'director-communications@epiphanycatholicchurch.org',
+        ],
+    },
+]
+```
+
+Each entry maps:
+- `source ps member wg`: Name of a PS Member Workgroup (the source of truth)
+- `target cc list`: Name of a CC List to synchronize
+- `notifications`: List of comma-delimited email address strings to notify when actions are performed on this CC List
+
+### 2.2 Config Resolution
+
+At runtime, the script resolves each synchronization entry:
+1. Finds the PS Member Workgroup by name and extracts its members (with email addresses)
+2. Finds the CC List by name and its current contacts
+3. Logs an error and exits if either is not found
+
+---
+
+## 3. Execution Flow
+
+### 3.1 High-Level Flow
+
+```
+1. Parse CLI arguments
+2. Set up logging
+3. Authenticate with CC (load_client_id + get_access_token); exit if --cc-auth-only
+4. Set up email
+5. Load PS data (families, members, workgroups)
+6. Download CC Contacts and Lists, build read-only indexes
+7. Resolve synchronization config → desired state per list
+8. Filter out CC-unsubscribed emails from desired state
+9. Compute action list (subscribe, unsubscribe, create, name updates)
+10. Log deletion candidates
+11. Execute action list (unless --dry-run or --no-sync)
+12. Send notification emails (unless --dry-run or --no-sync)
+13. Send unsubscribed-contacts report (if --unsubscribed-report; log-only if --dry-run)
+```
+
+### 3.2 Architecture: Immutable Data + Action List
+
+Downloaded CC contacts and PS members are treated as **read-only** after the indexing step. All sync logic produces an **action list** — a plain Python list of action dicts — without mutating any downloaded data. This replaces the legacy pattern of attaching action flags to contact dicts and mutating `list_memberships` in place.
+
+The action list is the single source of truth for:
+- **Execution**: grouped by email to minimize API calls
+- **Dry-run logging**: printed without executing
+- **Notification emails**: filtered by sync index
+
+#### 3.2.1 Action Dict Structure
+
+Each action in the action list is a dict:
+
+```python
+{
+    'type':       str,   # 'create', 'subscribe', 'unsubscribe', or 'update_name'
+    'email':      str,   # contact email address
+    'list_name':  str,   # CC list name (for subscribe/unsubscribe; None for others)
+    'list_uuid':  str,   # CC list UUID (for subscribe/unsubscribe; None for others)
+    'detail':     str,   # human-readable description for logging and email
+    'sync_index': int,   # index into SYNCHRONIZATIONS (for grouping notifications)
+}
+```
+
+Name update actions additionally carry:
+
+```python
+{
+    'new_first':  str,   # new first name
+    'new_last':   str,   # new last name
+    'old_first':  str,   # previous first name (for logging)
+    'old_last':   str,   # previous last name (for logging)
+}
+```
+
+### 3.3 Step Details
+
+#### 3.3.1 Load PS Data
+
+Call `ParishSoft.load_families_and_members()` with:
+- `active_only=True`
+- `parishioners_only=False`
+- Other parameters from CLI arguments (api_key, cache_dir)
+
+Returns: families, members, family_workgroups, member_workgroups, ministries
+
+#### 3.3.2 Authenticate and Load CC Data
+
+Authenticate using `ConstantContact.load_client_id()` and `ConstantContact.get_access_token()`. If `--cc-auth-only` is set, log a message and exit. Authentication runs early in `main()` (before PS data loading) so that `--cc-auth-only` does not require PS credentials.
+
+Download (after PS data loading):
+- **Contacts**: `api_get_all('contacts', 'contacts', include='list_memberships', status='all')`
+- **Lists**: `api_get_all('contact_lists', 'lists')`
+
+Normalize all CC contact email addresses to lowercase.
+
+#### 3.3.3 Build Read-Only Indexes
+
+After loading, build these lookup structures (all derived from the loaded data, treated as read-only from this point forward):
+
+1. Call `ConstantContact.link_cc_data(cc_contacts, [], cc_lists, log)`. This populates:
+   - `contact['LIST MEMBERSHIPS']`: list of human-readable list names
+   - `list['CONTACTS']`: dict of `{email: contact}` for each list
+
+2. Call `ConstantContact.link_contacts_to_ps_members(cc_contacts, members, log)`. This populates:
+   - `contact['PS MEMBERS']`: list of PS member dicts matching by email
+   - `member['CONTACT']`: back-reference to CC contact
+
+3. Build script-level indexes:
+   - `cc_contacts_by_email`: `{email: contact}` for quick contact lookup
+   - `ps_members_by_email`: `{email.lower(): [member, ...]}` for all PS members sharing that email (lowercase keys to match CC email normalization)
+
+These structures are **not modified** by any subsequent step.
+
+#### 3.3.4 Resolve Synchronization Config → Desired State
+
+For each entry in `SYNCHRONIZATIONS`:
+1. Find the PS Member Workgroup by name; extract members with email addresses into `desired_emails[i]` (a set of lowercase email strings). For each workgroup membership entry with a `'py member duid'` key, look up the full member from `ps_members[duid]` and include their first email if `member['emailAddress']` is truthy. Log a warning for members with no email.
+2. Find the CC List by name; store the list object in `sync['TARGET CC LIST']`.
+
+Log error and exit if a workgroup or list is not found.
+
+The result is a set of desired emails per sync entry: `desired_emails[i] = {email1, email2, ...}`.
+
+#### 3.3.5 Filter Out CC-Unsubscribed Emails
+
+For each CC Contact whose `email_address.permission_to_send` is `'unsubscribed'`:
+- Remove that email from every `desired_emails[i]` set
+- Record the removal for notification email reporting: for each sync where the email was present, store `(email, [PS member names], [PS member DUIDs])` in `unsubscribed_per_sync[i]`
+
+This prevents the script from re-subscribing contacts who manually opted out.
+
+#### 3.3.6 Compute Action List
+
+Compute all actions in a single pass, producing a flat action list without mutating any loaded data.
+
+**Step 1: Identify emails needing new contacts**
+
+```
+all_desired_emails = union of all desired_emails[i]
+emails_needing_contacts = all_desired_emails - set(cc_contacts_by_email.keys())
+```
+
+For each email needing a contact:
+- Collect all PS Members with that email from `ps_members_by_email`
+- Add a `create` action to the action list
+
+**Step 2: Per-list subscribe/unsubscribe**
+
+For each synchronization entry `i`:
+- `current_emails` = set of emails in `sync['TARGET CC LIST']['CONTACTS']`
+- `to_subscribe = desired_emails[i] - current_emails`
+- `to_unsubscribe = current_emails - desired_emails[i]`
+- Add `subscribe` actions and `unsubscribe` actions to the action list, each with `sync_index=i`
+
+**Step 3: Name mismatches**
+
+For each CC Contact in `cc_contacts_by_email` that has `'PS MEMBERS'`:
+1. Recompute the expected name using `ParishSoft.salutation_for_members(contact['PS MEMBERS'])`
+2. Strip periods from the expected first name (CC rejects periods)
+3. Compare with `contact.get('first_name', '')` and `contact.get('last_name', '')`
+4. Always log differences
+5. If `--update-names` is set, add an `update_name` action to the action list
+
+**Step 4: Deletion candidates (log only)**
+
+Log (but do NOT add to action list) any CC Contact meeting either condition:
+- `'PS MEMBERS'` key is absent or empty
+- The contact's current list memberships minus all `unsubscribe` actions for that email would be empty
+
+#### 3.3.7 Execute Action List
+
+Group actions by email to minimize API calls. For each email with actions:
+
+**POST call** (create + subscribe, or subscribe existing contact):
+- Collect all `create` and `subscribe` actions for this email
+- If the email needs a new contact: call `CC.create_contact_dict(email, ps_members, log)` to build the contact dict, set `list_memberships` to the list UUIDs from all subscribe actions
+- If the email has an existing contact: build a dict with `email_address`, `first_name`, `last_name` from the existing contact, and `list_memberships` = [only the NEW list UUIDs from subscribe actions]
+- Call `CC.create_or_update_contact(contact_dict, ...)` — the CC sign_up_form API **adds** to list memberships
+- One POST per contact
+
+**PUT call** (unsubscribe + name update):
+- Collect all `unsubscribe` and `update_name` actions for this email
+- Build a dict from the existing contact's fields: `contact_id`, `email_address` (full object), `first_name`, `last_name`, `list_memberships`
+- Set `list_memberships` = original contact's `list_memberships` minus all unsubscribe list UUIDs
+- If there's an `update_name` action: set `first_name` and `last_name` to the new values
+- Call `CC.update_contact_full(contact_dict, ...)` — the CC PUT API **replaces** list memberships with exactly what's sent
+- One PUT per contact
+
+**Error handling**: Wrap each CC API call in `try/except CCAPIError`. On failure, log the error and continue processing remaining contacts. Record failures `(email, action_type, error_message)` for inclusion in notification emails.
+
+**Dry-run mode** (`--dry-run`): Log all actions that would be performed, but do not make any CC API calls.
+
+**No-sync mode** (`--no-sync`): Same as dry-run for this step — log all actions that would be performed, but do not make any CC API calls. The difference from `--dry-run` is that `--no-sync` allows the unsubscribed-contacts report (Section 3.3.9) to send emails.
+
+#### 3.3.8 Send Notification Emails
+
+For each synchronization entry `i`, filter the action list by `sync_index == i`. If any actions exist for that list:
+
+1. Collect action descriptions for the list
+2. Collect unsubscribed contacts from `unsubscribed_per_sync[i]`
+3. Collect any failed actions for this list
+4. Build an HTML email (see Section 5)
+5. Send to each address in the sync's `notifications` list using `ECC.send_email()` with `content_type='text/html'`
+
+Do NOT send sync notification emails in dry-run mode or no-sync mode.
+
+#### 3.3.9 Send Unsubscribed-Contacts Report
+
+Only runs if `--unsubscribed-report` is set. This step runs **after** all normal sync actions and notification emails have completed.
+
+For each synchronization entry `i` where `unsubscribed_per_sync[i]` is non-empty:
+
+1. Build a standalone HTML email (see Section 5.4) listing the PS Members who are in the sync's PS Member Workgroup but whose CC Contact has `permission_to_send = 'unsubscribed'`
+2. Include the PS Member Workgroup name (`SYNCHRONIZATIONS[i]['source ps member wg']`) so recipients know which workgroup to update
+3. If `--dry-run`: log a warning that no email will be sent, then log the subject and the effective report contents (CC list name, PS workgroup name, and each unsubscribed member's name, DUID, and email) at info level. Do NOT send the email.
+4. Otherwise (including `--no-sync` without `--dry-run`): send to each address in `SYNCHRONIZATIONS[i]['notifications']` using `ECC.send_email()` with `content_type='text/html'`
+
+This email is **separate** from the sync update notification (Section 3.3.8). Its purpose is to inform administrators which PS Members should be removed from the PS Member Workgroup because they have manually unsubscribed from Constant Contact.
+
+---
+
+## 4. CLI Arguments
+
+Use standard `argparse`. Required and optional arguments:
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `--ps-api-keyfile` | Yes | — | File containing the ParishSoft API key |
+| `--cc-client-id` | No | `constant-contact-client-id.json` | File containing the CC Client ID |
+| `--cc-access-token` | No | `constant-contact-access-token.json` | File containing the CC access token |
+| `--service-account-json` | No | `ecc-emailer-service-account.json` | Google service account JSON key file |
+| `--impersonated-user` | No | `no-reply@epiphanycatholicchurch.org` | Google Workspace user to impersonate via DWD |
+| `--ps-cache-dir` | No | `datacache` | Directory to cache PS data |
+| `--cc-auth-only` | No | `False` | Only authenticate to CC, then exit |
+| `--update-names` | No | `False` | Update CC Contact names from PS data when they differ |
+| `--unsubscribed-report` | No | `False` | Generate and send standalone report of PS Members whose CC Contacts have unsubscribed |
+| `--no-sync` | No | `False` | Skip sync execution and sync notification emails. All computation still runs. Unlike `--dry-run`, allows `--unsubscribed-report` to send emails |
+| `--dry-run` | No | `False` | Log actions without executing. No emails sent. Implies `--verbose` |
+| `--verbose` | No | `False` | Emit extra status messages |
+| `--debug` | No | `False` | Emit debug-level messages. Implies `--verbose` |
+| `--logfile` | No | `log.txt` | File for verbose/debug log output |
+
+---
+
+## 5. Notification Email Format
+
+Each notification email is clean, professional HTML. One email is sent per CC List per notification address when actions occur.
+
+### 5.1 Email Structure
+
+```
+Subject: Constant Contact sync update: {CC List Name}
+
+Body:
+  1. Header with CC List name and timestamp
+  2. Summary counts (contacts created, subscribed, unsubscribed, failures)
+  3. Table of actions performed (action type, contact email, contact name)
+  4. Section: "Manually Unsubscribed Contacts"
+     - Contacts globally unsubscribed from CC (permission_to_send = 'unsubscribed')
+       who have PS Members in this sync's workgroup
+     - Table: email, PS Member name(s), PS Member DUID(s)
+  5. Section: "Contacts Removed from List (in ParishSoft)"
+     - Contacts removed from this specific CC List by this sync run
+     - Table: email, contact name, reason
+  6. Footer noting this is an automated message
+```
+
+### 5.2 Styling
+
+- Clean, professional HTML suitable for email clients
+- Use inline CSS (email clients strip `<style>` blocks)
+- Tables with borders, alternating row colors for readability
+- Clear section headings
+- No images or external resources (for email deliverability)
+
+### 5.3 Failed Actions
+
+If any individual contact updates failed during execution, include a "Failed Actions" section in the email listing the contact email, intended action, and error message.
+
+### 5.4 Unsubscribed-Contacts Report Email
+
+A standalone email sent when `--unsubscribed-report` is set. One email per CC List per notification address, only for lists that have unsubscribed PS Members. This is a separate email from the sync notification in Section 5.1.
+
+```
+Subject: Constant Contact unsubscribed contacts report: {CC List Name}
+
+Body:
+  1. Header with CC List name and timestamp
+  2. Explanation paragraph:
+     "The following ParishSoft Members are in the '{PS Workgroup Name}'
+     workgroup but have manually unsubscribed from Constant Contact.
+     They should be removed from the '{PS Workgroup Name}' workgroup
+     in ParishSoft."
+  3. Table: PS Member name(s), PS Member DUID(s), email address
+  4. Footer noting this is an automated message
+```
+
+Follows the same styling guidelines as Section 5.2 (inline CSS, bordered tables with alternating row colors, no images).
+
+---
+
+## 6. Error Handling
+
+### 6.1 CC API Errors
+
+The updated `ConstantContact.py` module raises `CCAPIError` exceptions on non-2xx responses (see ConstantContact spec).
+
+**Bulk data loading** (GET all contacts, GET all lists): If these fail, the script cannot proceed. Let the exception propagate and terminate the script.
+
+**Individual contact updates** (PUT/POST): Catch `CCAPIError`, log the failure, and continue processing remaining contacts. Accumulate failures for the notification email.
+
+### 6.2 PS Data Loading
+
+If PS data loading fails, let the exception propagate and terminate the script (same as current behavior).
+
+### 6.3 Configuration Errors
+
+If a PS Member Workgroup or CC List from `SYNCHRONIZATIONS` is not found, log an error and exit.
+
+---
+
+## 7. Corner Cases
+
+### 7.1 Multiple PS Members Sharing an Email
+
+Multiple PS Members may have the same email address (e.g., a married couple sharing `family@example.com`). This means:
+
+- A single CC Contact maps to multiple PS Members
+- The contact's name is derived from all linked members via `salutation_for_members()`
+- If any of those members is in a synced workgroup, the contact should be on the corresponding CC List
+
+The `ps_members_by_email` index (Section 3.3.3) naturally collects all members sharing an email, making it straightforward to collect them when creating a new contact.
+
+### 7.2 Email Address Changes
+
+**Members who used to share an email but now have different emails**:
+- The old CC Contact retains one or more members; the other members now need a new CC Contact
+- The old contact's name may need updating (if `--update-names`)
+- The new contact needs creating
+
+**Members who didn't share an email but now do**:
+- One of the old CC Contacts now maps to multiple members
+- That contact's name may need updating
+- The other old CC Contact may become a deletion candidate (no PS Members linked)
+
+Both scenarios are handled naturally by the set-diff computation: the diff between desired and current state produces the correct subscribe/unsubscribe/create actions without special-case code.
+
+### 7.3 CC-Unsubscribed Contacts
+
+Contacts who have globally unsubscribed from CC (`permission_to_send = 'unsubscribed'`) must NOT be re-subscribed. They are removed from the desired email sets before computing the diff.
+
+### 7.4 Period in First Names
+
+CC rejects contact names containing periods (e.g., `"T.J."`). Strip periods from `first_name` before comparison and before sending to the CC API. Note that `ConstantContact.py` also strips periods in `update_contact_full()` and `create_or_update_contact()`, but the script should strip them during comparison to avoid false-positive name mismatch detections.
+
+---
+
+## 8. Dependencies
+
+### 8.1 Internal Modules
+
+| Module | Import | Usage |
+|--------|--------|-------|
+| `ConstantContact` | `import ConstantContact as CC` | CC API operations |
+| `ParishSoftv2` | `import ParishSoftv2 as ParishSoft` | PS data loading and member queries |
+| `ECC` | `import ECC` | Logging setup, email sending |
+
+### 8.2 External Dependencies
+
+| Package | Usage |
+|---------|-------|
+| `argparse` | CLI argument parsing (stdlib) |
+| `logging` | Logging (stdlib) |
+
+### 8.3 Module Path
+
+The script uses the same `moddir` pattern as `sync-constant-contact.py` to add the `python/` directory to `sys.path`:
+```python
+moddir = '../../../python'
+```
+
+---
+
+## 9. Relationship to Existing Code
+
+### 9.1 ConstantContact.py Functions Used
+
+| Function | Purpose |
+|----------|---------|
+| `load_client_id()` | Load CC client ID config |
+| `get_access_token()` | Obtain/refresh CC OAuth2 token |
+| `api_get_all()` | Download all CC Contacts and Lists |
+| `link_cc_data()` | Cross-link contacts with lists |
+| `link_contacts_to_ps_members()` | Correlate CC Contacts to PS Members by email |
+| `create_contact_dict()` | Create in-memory CC Contact from PS Members |
+| `create_or_update_contact()` | POST to sign_up_form (create/subscribe) |
+| `update_contact_full()` | PUT to contacts/{id} (unsubscribe/update) |
+
+### 9.2 ParishSoftv2.py Functions Used
+
+| Function | Purpose |
+|----------|---------|
+| `load_families_and_members()` | Load all PS data |
+| `salutation_for_members()` | Compute contact name from PS Members |
+| `member_is_active()` | Check member active status (used indirectly) |
+| `family_is_active()` | Check family active status (used indirectly) |
+
+### 9.3 ECC.py Functions Used
+
+| Function | Purpose |
+|----------|---------|
+| `setup_logging()` | Configure logging |
+| `setup_email()` | Configure Gmail SMTP credentials |
+| `send_email()` | Send notification emails |
+
+---
+
+## 10. What This Script Does NOT Do
+
+- **Delete CC Contacts**: Deletion candidates are logged but never deleted
+- **Modify PS data**: PS is read-only source of truth
+- **Handle CC email campaigns**: Out of scope
+- **Proactively throttle requests**: Rate limiting is reactive (via 429 handling in ConstantContact.py)
+- **Mutate downloaded data**: CC contacts and PS members are read-only after indexing; sync logic produces an action list instead
+
+---
+
+## 11. Reconciliation Summary
+
+**Created**: 2026-03-01
+**Revised**: 2026-03-01 (adopted declarative diff architecture with immutable data + action list)
+**Derived from**: Analysis of `sync-constant-contact.py`, `ConstantContact.py` spec, `ParishSoftv2.py` spec, and requirements interview.
+
+This specification describes a new script. It has not yet been implemented.

--- a/specs/sync-ps-to-cc/tasks.md
+++ b/specs/sync-ps-to-cc/tasks.md
@@ -274,7 +274,7 @@
 
 ## Phase 7: Main Orchestration
 
-- [ ] **7.1** Implement `main()` function
+- [x] **7.1** Implement `main()` function
   - Wire all components together in the correct order:
     1. `args = setup_cli_args()`
     2. `log = ECC.setup_logging(info=args.verbose, debug=args.debug, logfile=args.logfile, rotate=True, slack_token_filename=None)`

--- a/specs/sync-ps-to-cc/tasks.md
+++ b/specs/sync-ps-to-cc/tasks.md
@@ -206,7 +206,7 @@
 
 ## Phase 6: HTML Notification Emails
 
-- [ ] **6.1** Implement HTML email builder function
+- [x] **6.1** Implement HTML email builder function
   - Create a `build_notification_email()` function that takes:
     - CC List name
     - List of actions for this list (each with type, email, detail)
@@ -229,7 +229,7 @@
   - Return the (subject, html_body) tuple.
   - _Spec: sections 5.1, 5.2, 5.3_
 
-- [ ] **6.2** Implement per-list notification email sending
+- [x] **6.2** Implement per-list notification email sending
   - Create a `send_notification_emails()` function that takes the action list, failures list, `unsubscribed_per_sync`, syncs, and `log`.
   - For each synchronization entry `i`:
     - Filter the action list by `sync_index == i` to get actions for this CC list.
@@ -241,7 +241,7 @@
   - _Depends: 6.1, 5.2_
   - _Spec: section 3.3.8_
 
-- [ ] **6.3** Implement unsubscribed-contacts report email builder
+- [x] **6.3** Implement unsubscribed-contacts report email builder
   - Create a `build_unsubscribed_report_email()` function that takes:
     - CC List name
     - PS Member Workgroup name (from `SYNCHRONIZATIONS[i]['source ps member wg']`)
@@ -256,7 +256,7 @@
   - Return the `(subject, html_body)` tuple.
   - _Spec: sections 3.3.9, 5.4_
 
-- [ ] **6.4** Implement unsubscribed-contacts report sending
+- [x] **6.4** Implement unsubscribed-contacts report sending
   - Create a `send_unsubscribed_report()` function that takes `unsubscribed_per_sync`, syncs, and `log`.
   - Only runs if `args.unsubscribed_report` is `True`.
   - For each synchronization entry `i` where `unsubscribed_per_sync[i]` is non-empty:

--- a/specs/sync-ps-to-cc/tasks.md
+++ b/specs/sync-ps-to-cc/tasks.md
@@ -209,33 +209,32 @@
 - [x] **6.1** Implement HTML email builder function
   - Create a `build_notification_email()` function that takes:
     - CC List name
+    - PS Member Workgroup name
     - List of actions for this list (each with type, email, detail)
     - List of failed actions for this list (each with email, action, error)
-    - List of manually unsubscribed contacts (each with email, PS Member names, PS Member DUIDs) — from `unsubscribed_per_sync[i]`
-    - List of contacts removed from this list — `unsubscribe` actions filtered for this list
+    - `cc_contacts_by_email` dict (for contact name and PS MEMBERS lookup)
+    - `ps_members_by_email` dict (fallback for DUID lookup on newly-created contacts)
   - Build a complete HTML email with:
     - **Subject**: `Constant Contact sync update: {CC List Name}`
     - **Header**: CC List name and current timestamp
-    - **Summary counts**: contacts created, subscribed, unsubscribed, failures
-    - **Actions table**: columns: action type, contact email, contact name
-    - **"Manually Unsubscribed Contacts" section**: table with columns: email, PS Member name(s), PS Member DUID(s)
-    - **"Contacts Removed from List (in ParishSoft)" section**: table with columns: email, contact name, reason
-    - **"Failed Actions" section** (only if failures occurred): table with columns: contact email, intended action, error message
+    - **ParishSoft Member Workgroup** and **Constant Contact List** names
+    - **Summary counts**: contacts subscribed, contacts unsubscribed, update failures
+    - **"Actions Performed" table**: grouped by action type (subscribe, unsubscribe) with blue separator rows between groups; sorted by (last_name, first_name) within each group. Columns: Action, Contact Name(s), ParishSoft Member DUID(s), Email. "create" and "update_name" actions are filtered out before rendering.
+    - **"Failed Actions" section** (only if failures occurred): table with columns: Contact Name(s), ParishSoft Member DUID(s), Email, Action, Update error. Sorted by (last_name, first_name).
     - **Footer**: "This is an automated message" note
   - Use inline CSS only (email clients strip `<style>` blocks).
-  - Tables with borders, alternating row colors (`#f2f2f2` / `#ffffff` or similar).
-  - Clear section headings with appropriate font sizes.
+  - Tables: auto-width, left-justified, bordered, alternating row colors (`#f2f2f2` / `#ffffff`). Column headings centered with blue background (`#4472C4`), white text. Cells use `white-space: nowrap`.
   - No images or external resources.
   - Return the (subject, html_body) tuple.
   - _Spec: sections 5.1, 5.2, 5.3_
 
 - [x] **6.2** Implement per-list notification email sending
-  - Create a `send_notification_emails()` function that takes the action list, failures list, `unsubscribed_per_sync`, syncs, and `log`.
+  - Create a `send_notification_emails()` function that takes the action list, failures list, `unsubscribed_per_sync`, `cc_contacts_by_email`, `ps_members_by_email`, syncs, and `log`.
   - For each synchronization entry `i`:
     - Filter the action list by `sync_index == i` to get actions for this CC list.
     - If no actions exist for this list, skip it.
     - Filter the failures list for emails that have actions in this sync.
-    - Call `build_notification_email()` with the filtered data.
+    - Call `build_notification_email()` with the CC list name, PS workgroup name, filtered actions, filtered failures, `cc_contacts_by_email`, and `ps_members_by_email`.
     - For each comma-delimited address string in `sync['notifications']`, split by comma and send to each address using `ECC.send_email(to_addr=addr.strip(), subject=subject, body=html, content_type='text/html', log=log)`.
   - Skip entirely if `args.dry_run` is `True` or `args.no_sync` is `True`.
   - _Depends: 6.1, 5.2_
@@ -249,10 +248,11 @@
   - Build a complete HTML email with:
     - **Subject**: `Constant Contact unsubscribed contacts report: {CC List Name}`
     - **Header**: CC List name and current timestamp
-    - **Explanation paragraph**: "The following ParishSoft Members are in the '{PS Workgroup Name}' workgroup but have manually unsubscribed from Constant Contact. They should be removed from the '{PS Workgroup Name}' workgroup in ParishSoft."
-    - **Table**: columns: PS Member name(s), PS Member DUID(s), email address
+    - **Explanation paragraph**: "The following ParishSoft Members are in the '{PS Workgroup Name}' workgroup but have manually unsubscribed from Constant Contact."
+    - **Bold red warning paragraph** (16px): "These ParishSoft Members should be removed from the '{PS Workgroup Name}' workgroup in ParishSoft."
+    - **Table**: columns: PS Member name(s), PS Member DUID(s), email address. Sorted by last name then first name.
     - **Footer**: "This is an automated message" note
-  - Use the same inline CSS styling as `build_notification_email()` (bordered tables, alternating row colors, clear headings, no images).
+  - Use the same inline CSS styling as `build_notification_email()` (auto-width tables, bordered, alternating row colors, centered column headings, `white-space: nowrap`, no images).
   - Return the `(subject, html_body)` tuple.
   - _Spec: sections 3.3.9, 5.4_
 

--- a/specs/sync-ps-to-cc/tasks.md
+++ b/specs/sync-ps-to-cc/tasks.md
@@ -102,7 +102,7 @@
 
 ## Phase 3: Desired State and Filtering
 
-- [ ] **3.1** Resolve synchronization config to desired email sets
+- [x] **3.1** Resolve synchronization config to desired email sets
   - Create a `resolve_desired_state()` function (or similar).
   - For each entry `i` in `SYNCHRONIZATIONS`:
     1. **Resolve PS Member Workgroup**: search `member_workgroups` (dict of dicts) by `wg['name'] == sync['source ps member wg']`. For each workgroup membership entry with a `'py member duid'` key, look up the full member from `members[duid]`. If `member['emailAddress']` is truthy, add `member['py emailAddresses'][0].lower()` to `desired_emails[i]` (a set). Log a warning for members in the workgroup with no email. Log info with member count on success.
@@ -111,7 +111,7 @@
   - Return `desired_emails` (a list of sets, one per sync entry) and the resolved synchronizations.
   - _Spec: section 3.3.4, 6.3_
 
-- [ ] **3.2** Filter out CC-unsubscribed emails from desired state
+- [x] **3.2** Filter out CC-unsubscribed emails from desired state
   - Create a `filter_unsubscribed()` function.
   - Initialize `unsubscribed_per_sync`: a list of lists (one per sync entry), each holding `(email, member_names_str, member_duids_str)` tuples for notification email reporting.
   - Iterate all `cc_contacts`. For each contact where `contact['email_address']['permission_to_send'] == 'unsubscribed'`:

--- a/specs/sync-ps-to-cc/tasks.md
+++ b/specs/sync-ps-to-cc/tasks.md
@@ -129,7 +129,7 @@
 
 ## Phase 4: Compute Action List
 
-- [ ] **4.1** Identify emails needing new contacts and add `create` actions
+- [x] **4.1** Identify emails needing new contacts and add `create` actions
   - Compute `all_desired_emails = union(desired_emails[0], desired_emails[1], ...)`.
   - Compute `emails_needing_contacts = all_desired_emails - set(cc_contacts_by_email.keys())`.
   - For each email in `emails_needing_contacts`:
@@ -139,7 +139,7 @@
   - _Depends: 2.5, 3.2_
   - _Spec: section 3.3.6 (step 1)_
 
-- [ ] **4.2** Compute per-list subscribe and unsubscribe actions
+- [x] **4.2** Compute per-list subscribe and unsubscribe actions
   - For each synchronization entry `i`:
     - Get the CC list object from `sync['TARGET CC LIST']`, its UUID from `list['list_id']`, and its name from `sync['target cc list']`.
     - `current_emails = set(sync['TARGET CC LIST']['CONTACTS'].keys())`
@@ -151,7 +151,7 @@
   - _Depends: 3.1, 4.1_
   - _Spec: section 3.3.6 (step 2)_
 
-- [ ] **4.3** Detect name mismatches and add optional `update_name` actions
+- [x] **4.3** Detect name mismatches and add optional `update_name` actions
   - For each email in `cc_contacts_by_email` where the contact has `'PS MEMBERS'`:
     1. Call `ParishSoft.salutation_for_members(contact['PS MEMBERS'])` to get `(expected_first, expected_last)`.
     2. Strip periods from `expected_first` (e.g., `"T.J."` → `"TJ"`).
@@ -162,7 +162,7 @@
   - _Depends: 2.5_
   - _Spec: section 3.3.6 (step 3), 7.4_
 
-- [ ] **4.4** Log deletion candidates
+- [x] **4.4** Log deletion candidates
   - For each CC Contact in `cc_contacts_by_email.values()`:
     - Check if `'PS MEMBERS'` is absent or empty → log as deletion candidate.
     - Compute the contact's post-sync list count: `len(contact['list_memberships'])` minus the number of `unsubscribe` actions in the action list for this email. If zero → log as deletion candidate.

--- a/specs/sync-ps-to-cc/tasks.md
+++ b/specs/sync-ps-to-cc/tasks.md
@@ -58,7 +58,7 @@
 
 ## Phase 2: Data Loading and Indexing
 
-- [ ] **2.1** Implement PS data loading
+- [x] **2.1** Implement PS data loading
   - Create a function (or inline in `main()`) that calls `ParishSoft.load_families_and_members()` with:
     - `api_key=args.api_key`
     - `active_only=True`
@@ -69,7 +69,7 @@
   - Log that PS data is being loaded (info level).
   - _Spec: section 3.3.1_
 
-- [ ] **2.2** Implement CC authentication and data loading
+- [x] **2.2** Implement CC authentication and data loading
   - **Authentication** (runs early in `main()`, before PS data loading):
     - Call `CC.load_client_id(args.cc_client_id, log)` and `CC.get_access_token(args.cc_access_token, cc_client_id, log)`.
     - If `args.cc_auth_only` is set, log a message and `exit(0)`.
@@ -79,19 +79,19 @@
     - Contacts: `CC.api_get_all(cc_client_id, cc_access_token, 'contacts', 'contacts', log, include='list_memberships', status='all')`
   - _Spec: section 3.3.2, 6.1_
 
-- [ ] **2.3** Normalize CC contact emails to lowercase
+- [x] **2.3** Normalize CC contact emails to lowercase
   - After downloading contacts, iterate all contacts and lowercase `contact['email_address']['address']`.
   - _Depends: 2.2_
   - _Spec: section 3.3.2_
 
-- [ ] **2.4** Link CC data and correlate with PS Members
+- [x] **2.4** Link CC data and correlate with PS Members
   - Call `CC.link_cc_data(cc_contacts, [], cc_lists, log)`. This populates `contact['LIST MEMBERSHIPS']` and `list['CONTACTS']`.
   - Call `CC.link_contacts_to_ps_members(cc_contacts, members, log)`. This populates `contact['PS MEMBERS']` and `member['CONTACT']`.
   - These calls mutate the downloaded data to add cross-references, but the cross-referenced data is treated as **read-only** from this point forward.
   - _Depends: 2.1, 2.2, 2.3_
   - _Spec: section 3.3.3_
 
-- [ ] **2.5** Build script-level read-only indexes
+- [x] **2.5** Build script-level read-only indexes
   - Build `cc_contacts_by_email`: `{email: contact}` dict for quick contact lookup by email address.
   - Build `ps_members_by_email`: `{email: [member, ...]}` dict collecting ALL PS members sharing each email. Iterate `members.values()`, skip members with no `emailAddress`, use `member['py emailAddresses'][0].lower()` as the key (lowercase to match CC email normalization).
   - These indexes are **not modified** by any subsequent step.

--- a/specs/sync-ps-to-cc/tasks.md
+++ b/specs/sync-ps-to-cc/tasks.md
@@ -175,7 +175,7 @@
 
 ## Phase 5: Execute Action List
 
-- [ ] **5.1** Group actions by email and build contact dicts for CC API calls
+- [x] **5.1** Group actions by email and build contact dicts for CC API calls
   - Create an `execute_actions()` function that takes the action list, `cc_contacts_by_email`, `ps_members_by_email`, CC credentials, and `log`.
   - Group actions by email: `actions_by_email = defaultdict(list); for a in actions: actions_by_email[a['email']].append(a)`.
   - For each email:
@@ -190,7 +190,7 @@
   - _Depends: 4.1, 4.2, 4.3_
   - _Spec: section 3.3.7_
 
-- [ ] **5.2** Execute API calls with error handling and dry-run support
+- [x] **5.2** Execute API calls with error handling and dry-run support
   - For each email's POST dict (if built): call `CC.create_or_update_contact(post_dict, cc_client_id, cc_access_token, log)`.
   - For each email's PUT dict (if built): call `CC.update_contact_full(put_dict, cc_client_id, cc_access_token, log)`.
   - Wrap each CC API call in `try/except CCAPIError`. On failure:

--- a/specs/sync-ps-to-cc/tasks.md
+++ b/specs/sync-ps-to-cc/tasks.md
@@ -1,0 +1,329 @@
+# sync-ps-to-cc.py - Implementation Tasks
+
+> Auto-generated from `specs/sync-ps-to-cc/spec.md`. Each task maps to a spec section.
+> Mark tasks: `[ ]` pending, `[~]` in progress, `[x]` done, `[-]` skipped, `[!]` blocked.
+
+---
+
+## Phase 1: Configuration Module and Script Scaffolding
+
+- [ ] **1.1** Create `cc_sync_config.py` with `SYNCHRONIZATIONS` list
+  - Create file at `media/linux/ps-queries/cc_sync_config.py`.
+  - Define a module-level `SYNCHRONIZATIONS` list of dicts. Each dict has three keys:
+    - `'source ps member wg'`: string — PS Member Workgroup name (e.g., `'Daily Gospel Reflections'`, `'Parish-wide Email'`)
+    - `'target cc list'`: string — CC List name (e.g., `'SYNC Daily Gospel Reflections'`, `'SYNC Parish-wide Email'`)
+    - `'notifications'`: list of comma-delimited email address strings (e.g., `['ps-constantcontact-sync@epiphanycatholicchurch.org,director-communications@epiphanycatholicchurch.org']`)
+  - Populate with the two synchronization entries from the existing `get_synchronizations()` function in `sync-constant-contact.py` (lines 81-92).
+  - No imports needed; this is a pure-data module.
+  - _Spec: section 2.1_
+
+- [ ] **1.2** Create `sync-ps-to-cc.py` with module path handling and imports
+  - Create file at `media/linux/ps-queries/sync-ps-to-cc.py`.
+  - Add shebang `#!/usr/bin/env python3`.
+  - Replicate the `moddir` pattern from `sync-constant-contact.py` (lines 20-32): resolve `'../../../python'`, handle the MS Windows symlink-as-file quirk (read the file contents as the path), insert into `sys.path`.
+  - Import modules:
+    - `import ECC`
+    - `import ParishSoftv2 as ParishSoft`
+    - `import ConstantContact as CC`
+    - `from ConstantContact import CCAPIError`
+    - `from cc_sync_config import SYNCHRONIZATIONS`
+  - Import stdlib: `os`, `sys`, `argparse`, `logging`, `datetime`.
+  - Import `pprint.pformat` for debug logging.
+  - Add `if __name__ == '__main__': main()` at the bottom.
+  - _Spec: sections 8.1, 8.2, 8.3_
+
+- [ ] **1.3** Implement CLI argument parsing with `argparse`
+  - Create a `setup_cli_args()` function that uses standard `argparse.ArgumentParser` (NOT `oauth2client.tools.argparser`).
+  - Define arguments:
+    - `--ps-api-keyfile` (required): ParishSoft API key file
+    - `--cc-client-id` (default `'constant-contact-client-id.json'`): CC Client ID file
+    - `--cc-access-token` (default `'constant-contact-access-token.json'`): CC access token file
+    - `--service-account-json` (default `'ecc-emailer-service-account.json'`): Google service account JSON key file
+    - `--impersonated-user` (default `'no-reply@epiphanycatholicchurch.org'`): Google Workspace user to impersonate via DWD
+    - `--ps-cache-dir` (default `'datacache'`): directory to cache PS data
+    - `--cc-auth-only` (default `False`, `action='store_true'`): only authenticate to CC, then exit
+    - `--update-names` (default `False`, `action='store_true'`): update CC Contact names from PS data when they differ
+    - `--unsubscribed-report` (default `False`, `action='store_true'`): generate and send standalone report of PS Members whose CC Contacts have unsubscribed
+    - `--no-sync` (default `False`, `action='store_true'`): skip sync execution and sync notification emails; all computation still runs; unlike `--dry-run`, allows `--unsubscribed-report` to send emails
+    - `--dry-run` (default `False`, `action='store_true'`): log actions without executing; no emails sent; implies `--verbose`
+    - `--verbose` (default `False`, `action='store_true'`): emit extra status messages
+    - `--debug` (default `False`, `action='store_true'`): emit debug-level messages; implies `--verbose`
+    - `--logfile` (default `'log.txt'`): file for verbose/debug log output
+  - After parsing: `--dry-run` implies `--verbose`; `--debug` implies `--verbose`.
+  - Read the PS API key from the file specified by `--ps-api-keyfile`: check file exists (exit with error if not), read and `.strip()` the contents, store in `args.api_key`.
+  - Return the `args` namespace.
+  - _Spec: section 4_
+
+---
+
+## Phase 2: Data Loading and Indexing
+
+- [ ] **2.1** Implement PS data loading
+  - Create a function (or inline in `main()`) that calls `ParishSoft.load_families_and_members()` with:
+    - `api_key=args.api_key`
+    - `active_only=True`
+    - `parishioners_only=False`
+    - `cache_dir=args.ps_cache_dir`
+    - `log=log`
+  - Unpack the 5-tuple return: `families, members, family_workgroups, member_workgroups, ministries`.
+  - Log that PS data is being loaded (info level).
+  - _Spec: section 3.3.1_
+
+- [ ] **2.2** Implement CC authentication and data loading
+  - **Authentication** (runs early in `main()`, before PS data loading):
+    - Call `CC.load_client_id(args.cc_client_id, log)` and `CC.get_access_token(args.cc_access_token, cc_client_id, log)`.
+    - If `args.cc_auth_only` is set, log a message and `exit(0)`.
+  - **Download** (runs after PS data loading):
+    - Let `CCAPIError` propagate on failure — do NOT catch it here.
+    - Lists: `CC.api_get_all(cc_client_id, cc_access_token, 'contact_lists', 'lists', log)`
+    - Contacts: `CC.api_get_all(cc_client_id, cc_access_token, 'contacts', 'contacts', log, include='list_memberships', status='all')`
+  - _Spec: section 3.3.2, 6.1_
+
+- [ ] **2.3** Normalize CC contact emails to lowercase
+  - After downloading contacts, iterate all contacts and lowercase `contact['email_address']['address']`.
+  - _Depends: 2.2_
+  - _Spec: section 3.3.2_
+
+- [ ] **2.4** Link CC data and correlate with PS Members
+  - Call `CC.link_cc_data(cc_contacts, [], cc_lists, log)`. This populates `contact['LIST MEMBERSHIPS']` and `list['CONTACTS']`.
+  - Call `CC.link_contacts_to_ps_members(cc_contacts, members, log)`. This populates `contact['PS MEMBERS']` and `member['CONTACT']`.
+  - These calls mutate the downloaded data to add cross-references, but the cross-referenced data is treated as **read-only** from this point forward.
+  - _Depends: 2.1, 2.2, 2.3_
+  - _Spec: section 3.3.3_
+
+- [ ] **2.5** Build script-level read-only indexes
+  - Build `cc_contacts_by_email`: `{email: contact}` dict for quick contact lookup by email address.
+  - Build `ps_members_by_email`: `{email: [member, ...]}` dict collecting ALL PS members sharing each email. Iterate `members.values()`, skip members with no `emailAddress`, use `member['py emailAddresses'][0].lower()` as the key (lowercase to match CC email normalization).
+  - These indexes are **not modified** by any subsequent step.
+  - _Depends: 2.4_
+  - _Spec: section 3.3.3_
+
+---
+
+## Phase 3: Desired State and Filtering
+
+- [ ] **3.1** Resolve synchronization config to desired email sets
+  - Create a `resolve_desired_state()` function (or similar).
+  - For each entry `i` in `SYNCHRONIZATIONS`:
+    1. **Resolve PS Member Workgroup**: search `member_workgroups` (dict of dicts) by `wg['name'] == sync['source ps member wg']`. For each workgroup membership entry with a `'py member duid'` key, look up the full member from `members[duid]`. If `member['emailAddress']` is truthy, add `member['py emailAddresses'][0].lower()` to `desired_emails[i]` (a set). Log a warning for members in the workgroup with no email. Log info with member count on success.
+    2. **Resolve CC List**: search `cc_lists` (list of dicts) by `l['name'] == sync['target cc list']`. Store the list dict in `sync['TARGET CC LIST']`.
+    3. If either the workgroup or list is not found, log an error and `exit(1)`.
+  - Return `desired_emails` (a list of sets, one per sync entry) and the resolved synchronizations.
+  - _Spec: section 3.3.4, 6.3_
+
+- [ ] **3.2** Filter out CC-unsubscribed emails from desired state
+  - Create a `filter_unsubscribed()` function.
+  - Initialize `unsubscribed_per_sync`: a list of lists (one per sync entry), each holding `(email, member_names_str, member_duids_str)` tuples for notification email reporting.
+  - Iterate all `cc_contacts`. For each contact where `contact['email_address']['permission_to_send'] == 'unsubscribed'`:
+    - Get the contact's email.
+    - For each `desired_emails[i]` set that contains this email:
+      - Remove the email from `desired_emails[i]`.
+      - Look up PS members for this email (from `ps_members_by_email` or `contact['PS MEMBERS']`).
+      - Record `(email, member names, member DUIDs)` in `unsubscribed_per_sync[i]`.
+    - Log each removal at info level.
+  - Return `unsubscribed_per_sync` for later use in notification emails.
+  - _Depends: 2.5, 3.1_
+  - _Spec: section 3.3.5_
+
+---
+
+## Phase 4: Compute Action List
+
+- [ ] **4.1** Identify emails needing new contacts and add `create` actions
+  - Compute `all_desired_emails = union(desired_emails[0], desired_emails[1], ...)`.
+  - Compute `emails_needing_contacts = all_desired_emails - set(cc_contacts_by_email.keys())`.
+  - For each email in `emails_needing_contacts`:
+    - Add a `create` action to the action list: `{'type': 'create', 'email': email, 'list_name': None, 'list_uuid': None, 'detail': f'Create contact for {email}', 'sync_index': <first matching index>}`.
+    - Set `sync_index` to the index of the first `desired_emails[i]` set containing this email so the create action appears in that sync's notification email.
+  - **Corner case**: Multiple PS Members may share an email. The `ps_members_by_email` index naturally collects all such members, which will be used at execution time when calling `CC.create_contact_dict()`.
+  - _Depends: 2.5, 3.2_
+  - _Spec: section 3.3.6 (step 1)_
+
+- [ ] **4.2** Compute per-list subscribe and unsubscribe actions
+  - For each synchronization entry `i`:
+    - Get the CC list object from `sync['TARGET CC LIST']`, its UUID from `list['list_id']`, and its name from `sync['target cc list']`.
+    - `current_emails = set(sync['TARGET CC LIST']['CONTACTS'].keys())`
+    - `to_subscribe = desired_emails[i] - current_emails`
+    - `to_unsubscribe = current_emails - desired_emails[i]`
+    - For each email in `to_subscribe`: add `{'type': 'subscribe', 'email': email, 'list_name': list_name, 'list_uuid': list_uuid, 'detail': f'Subscribe {email} to {list_name}', 'sync_index': i}`.
+    - For each email in `to_unsubscribe`: add `{'type': 'unsubscribe', 'email': email, 'list_name': list_name, 'list_uuid': list_uuid, 'detail': f'Unsubscribe {email} from {list_name}', 'sync_index': i}`.
+  - No data is mutated — the action list is the only output.
+  - _Depends: 3.1, 4.1_
+  - _Spec: section 3.3.6 (step 2)_
+
+- [ ] **4.3** Detect name mismatches and add optional `update_name` actions
+  - For each email in `cc_contacts_by_email` where the contact has `'PS MEMBERS'`:
+    1. Call `ParishSoft.salutation_for_members(contact['PS MEMBERS'])` to get `(expected_first, expected_last)`.
+    2. Strip periods from `expected_first` (e.g., `"T.J."` → `"TJ"`).
+    3. Compare `expected_first` with `contact.get('first_name', '')` and `expected_last` with `contact.get('last_name', '')`.
+    4. Always log differences at info level (email, old name, expected name).
+    5. If `args.update_names` is `True` and a difference exists: add `{'type': 'update_name', 'email': email, 'list_name': None, 'list_uuid': None, 'detail': f'Update name for {email}: ...', 'sync_index': None, 'new_first': expected_first, 'new_last': expected_last, 'old_first': contact.get('first_name', ''), 'old_last': contact.get('last_name', '')}`.
+  - For notification purposes, `sync_index` is `None` for name updates (they are not list-specific). Name update actions are logged but not included in per-list notification emails.
+  - _Depends: 2.5_
+  - _Spec: section 3.3.6 (step 3), 7.4_
+
+- [ ] **4.4** Log deletion candidates
+  - For each CC Contact in `cc_contacts_by_email.values()`:
+    - Check if `'PS MEMBERS'` is absent or empty → log as deletion candidate.
+    - Compute the contact's post-sync list count: `len(contact['list_memberships'])` minus the number of `unsubscribe` actions in the action list for this email. If zero → log as deletion candidate.
+  - Log each candidate at info level with email and contact name (`contact.get('first_name', '')`, `contact.get('last_name', '')`).
+  - Do NOT add to the action list. Do NOT delete anything.
+  - _Depends: 4.2_
+  - _Spec: section 3.3.6 (step 4)_
+
+---
+
+## Phase 5: Execute Action List
+
+- [ ] **5.1** Group actions by email and build contact dicts for CC API calls
+  - Create an `execute_actions()` function that takes the action list, `cc_contacts_by_email`, `ps_members_by_email`, CC credentials, and `log`.
+  - Group actions by email: `actions_by_email = defaultdict(list); for a in actions: actions_by_email[a['email']].append(a)`.
+  - For each email:
+    - Separate actions into: `creates`, `subscribes`, `unsubscribes`, `name_updates`.
+    - **POST dict** (if any creates or subscribes):
+      - If email needs a new contact (`creates` non-empty): call `CC.create_contact_dict(email, ps_members_by_email[email], log)`. Set `list_memberships` to the list UUIDs from all `subscribe` actions for this email.
+      - If email has an existing contact (`creates` empty, `subscribes` non-empty): build a dict with `email_address` (as `{'address': email}`), `first_name`, `last_name` copied from the existing contact, and `list_memberships` = [UUIDs from subscribe actions only — the CC sign_up_form API adds to existing memberships].
+    - **PUT dict** (if any unsubscribes or name_updates):
+      - Copy relevant fields from the existing contact: `contact_id`, `email_address` (full object), `first_name`, `last_name`, `list_memberships` (as a copy — do NOT modify the original).
+      - Remove all unsubscribe list UUIDs from the copied `list_memberships`.
+      - If `name_updates` exist: set `first_name` and `last_name` to the new values from the action.
+  - _Depends: 4.1, 4.2, 4.3_
+  - _Spec: section 3.3.7_
+
+- [ ] **5.2** Execute API calls with error handling and dry-run support
+  - For each email's POST dict (if built): call `CC.create_or_update_contact(post_dict, cc_client_id, cc_access_token, log)`.
+  - For each email's PUT dict (if built): call `CC.update_contact_full(put_dict, cc_client_id, cc_access_token, log)`.
+  - Wrap each CC API call in `try/except CCAPIError`. On failure:
+    - Log the error (including contact email, intended action, HTTP status code, response text from `e.status_code`, `e.response_text`).
+    - Continue processing remaining contacts (do NOT exit).
+    - Record the failure as `{'email': email, 'action': 'POST'|'PUT', 'error': str(e)}` in a failures list.
+  - **Dry-run / no-sync mode**: if `args.dry_run` or `args.no_sync`, log every action that WOULD be performed at info level but do NOT make any CC API calls. Do NOT record failures (there are none).
+  - Return the failures list.
+  - _Depends: 5.1_
+  - _Spec: section 3.3.7, 6.1_
+
+---
+
+## Phase 6: HTML Notification Emails
+
+- [ ] **6.1** Implement HTML email builder function
+  - Create a `build_notification_email()` function that takes:
+    - CC List name
+    - List of actions for this list (each with type, email, detail)
+    - List of failed actions for this list (each with email, action, error)
+    - List of manually unsubscribed contacts (each with email, PS Member names, PS Member DUIDs) — from `unsubscribed_per_sync[i]`
+    - List of contacts removed from this list — `unsubscribe` actions filtered for this list
+  - Build a complete HTML email with:
+    - **Subject**: `Constant Contact sync update: {CC List Name}`
+    - **Header**: CC List name and current timestamp
+    - **Summary counts**: contacts created, subscribed, unsubscribed, failures
+    - **Actions table**: columns: action type, contact email, contact name
+    - **"Manually Unsubscribed Contacts" section**: table with columns: email, PS Member name(s), PS Member DUID(s)
+    - **"Contacts Removed from List (in ParishSoft)" section**: table with columns: email, contact name, reason
+    - **"Failed Actions" section** (only if failures occurred): table with columns: contact email, intended action, error message
+    - **Footer**: "This is an automated message" note
+  - Use inline CSS only (email clients strip `<style>` blocks).
+  - Tables with borders, alternating row colors (`#f2f2f2` / `#ffffff` or similar).
+  - Clear section headings with appropriate font sizes.
+  - No images or external resources.
+  - Return the (subject, html_body) tuple.
+  - _Spec: sections 5.1, 5.2, 5.3_
+
+- [ ] **6.2** Implement per-list notification email sending
+  - Create a `send_notification_emails()` function that takes the action list, failures list, `unsubscribed_per_sync`, syncs, and `log`.
+  - For each synchronization entry `i`:
+    - Filter the action list by `sync_index == i` to get actions for this CC list.
+    - If no actions exist for this list, skip it.
+    - Filter the failures list for emails that have actions in this sync.
+    - Call `build_notification_email()` with the filtered data.
+    - For each comma-delimited address string in `sync['notifications']`, split by comma and send to each address using `ECC.send_email(to_addr=addr.strip(), subject=subject, body=html, content_type='text/html', log=log)`.
+  - Skip entirely if `args.dry_run` is `True` or `args.no_sync` is `True`.
+  - _Depends: 6.1, 5.2_
+  - _Spec: section 3.3.8_
+
+- [ ] **6.3** Implement unsubscribed-contacts report email builder
+  - Create a `build_unsubscribed_report_email()` function that takes:
+    - CC List name
+    - PS Member Workgroup name (from `SYNCHRONIZATIONS[i]['source ps member wg']`)
+    - List of unsubscribed contact tuples `(email, member_names_str, member_duids_str)` from `unsubscribed_per_sync[i]`
+  - Build a complete HTML email with:
+    - **Subject**: `Constant Contact unsubscribed contacts report: {CC List Name}`
+    - **Header**: CC List name and current timestamp
+    - **Explanation paragraph**: "The following ParishSoft Members are in the '{PS Workgroup Name}' workgroup but have manually unsubscribed from Constant Contact. They should be removed from the '{PS Workgroup Name}' workgroup in ParishSoft."
+    - **Table**: columns: PS Member name(s), PS Member DUID(s), email address
+    - **Footer**: "This is an automated message" note
+  - Use the same inline CSS styling as `build_notification_email()` (bordered tables, alternating row colors, clear headings, no images).
+  - Return the `(subject, html_body)` tuple.
+  - _Spec: sections 3.3.9, 5.4_
+
+- [ ] **6.4** Implement unsubscribed-contacts report sending
+  - Create a `send_unsubscribed_report()` function that takes `unsubscribed_per_sync`, syncs, and `log`.
+  - Only runs if `args.unsubscribed_report` is `True`.
+  - For each synchronization entry `i` where `unsubscribed_per_sync[i]` is non-empty:
+    - Call `build_unsubscribed_report_email()` with the CC list name, PS workgroup name, and unsubscribed tuples.
+    - If `args.dry_run`:
+      - Log a warning that `--unsubscribed-report` was requested but no email will be sent due to `--dry-run`.
+      - Log the effective report contents at info level: subject line, CC list name, PS workgroup name, and each unsubscribed member's name, DUID, and email.
+      - Do NOT send the email.
+    - Otherwise (including `--no-sync` without `--dry-run`): for each comma-delimited address string in `syncs[i]['notifications']`, split by comma and send to each address using `ECC.send_email(to_addr=addr.strip(), subject=subject, body=html, content_type='text/html', log=log)`.
+  - This runs **after** all normal sync actions and notification emails have completed.
+  - _Depends: 3.2, 6.3_
+  - _Spec: section 3.3.9_
+
+---
+
+## Phase 7: Main Orchestration
+
+- [ ] **7.1** Implement `main()` function
+  - Wire all components together in the correct order:
+    1. `args = setup_cli_args()`
+    2. `log = ECC.setup_logging(info=args.verbose, debug=args.debug, logfile=args.logfile, rotate=True, slack_token_filename=None)`
+    3. Authenticate CC (task 2.2: `load_client_id` + `get_access_token`); exit early if `--cc-auth-only`
+    4. `ECC.setup_email(service_account_json=args.service_account_json, impersonated_user=args.impersonated_user, log=log)`
+    5. Load PS data (task 2.1)
+    6. Download CC Contacts and Lists (task 2.2, download portion)
+    7. Normalize CC emails (task 2.3)
+    8. Link CC data and correlate with PS members (task 2.4)
+    9. Build script-level indexes (task 2.5)
+    10. Resolve desired state (task 3.1)
+    11. Filter out unsubscribed (task 3.2)
+    12. Compute action list: create actions (4.1), subscribe/unsubscribe (4.2), name mismatches (4.3), deletion candidates (4.4)
+    13. Execute action list — skip if `--dry-run` or `--no-sync` (tasks 5.1, 5.2)
+    14. Send notification emails — skip if `--dry-run` or `--no-sync` (task 6.2)
+    15. Send unsubscribed-contacts report — if `--unsubscribed-report`; log-only if `--dry-run` (task 6.4)
+  - _Depends: 1.2, 1.3, 2.1-2.5, 3.1, 3.2, 4.1-4.4, 5.1, 5.2, 6.1-6.4_
+  - _Spec: section 3.1_
+
+---
+
+## Phase 8: Edge Cases and Error Handling
+
+- [ ] **8.1** Verify shared-email handling throughout the pipeline
+  - The `ps_members_by_email` index (task 2.5) naturally collects all PS members sharing an email. Verify:
+    - `execute_actions()` passes the full list from `ps_members_by_email[email]` to `CC.create_contact_dict()` so the contact name is derived from ALL members.
+    - Set-diff in task 4.2: if ANY member sharing an email is in a workgroup, that email is in `desired_emails[i]`, so the contact is subscribed. This works because `desired_emails` is built from workgroup membership, not from individual members.
+    - `detect_name_mismatches()` uses `contact['PS MEMBERS']` (populated by `link_contacts_to_ps_members`), which already contains all members for that email.
+  - _Spec: section 7.1_
+
+- [ ] **8.2** Verify email-change scenarios are handled by the diff
+  - Confirm that the set-diff architecture handles these without special code:
+    - **Members split emails**: old contact retains some members; new email appears in `emails_needing_contacts` → gets a `create` action. Old contact may get `update_name` action.
+    - **Members merge emails**: one contact now maps to multiple members; the other contact loses its PS members → logged as deletion candidate.
+  - If any scenario is not handled, add corrective logic. Otherwise, add a comment in the code documenting why it works.
+  - _Spec: section 7.2_
+
+- [ ] **8.3** Handle contacts with missing name fields
+  - Ensure `detect_name_mismatches()` (task 4.3) and any name-display code use `contact.get('first_name', '')` and `contact.get('last_name', '')` since CC contacts can lack these fields.
+  - Ensure the `detail` string in actions handles missing names gracefully.
+  - _Depends: 4.3_
+  - _Spec: section 3.3.6 (step 3)_
+
+- [ ] **8.4** Ensure bulk data loading failures terminate the script
+  - Verify that `CCAPIError` from `CC.api_get_all()` calls (contacts and lists) is NOT caught — it should propagate and terminate the script. Only the `execute_actions()` function catches `CCAPIError` (for individual contact updates).
+  - _Depends: 2.2, 5.2_
+  - _Spec: section 6.1_
+
+- [ ] **8.5** Ensure config resolution failures terminate the script
+  - Verify that if a PS Member Workgroup name or CC List name from `SYNCHRONIZATIONS` is not found, the script logs an error and calls `exit(1)`.
+  - _Depends: 3.1_
+  - _Spec: section 6.3_

--- a/specs/sync-ps-to-cc/tasks.md
+++ b/specs/sync-ps-to-cc/tasks.md
@@ -7,7 +7,7 @@
 
 ## Phase 1: Configuration Module and Script Scaffolding
 
-- [ ] **1.1** Create `cc_sync_config.py` with `SYNCHRONIZATIONS` list
+- [x] **1.1** Create `cc_sync_config.py` with `SYNCHRONIZATIONS` list
   - Create file at `media/linux/ps-queries/cc_sync_config.py`.
   - Define a module-level `SYNCHRONIZATIONS` list of dicts. Each dict has three keys:
     - `'source ps member wg'`: string — PS Member Workgroup name (e.g., `'Daily Gospel Reflections'`, `'Parish-wide Email'`)
@@ -17,7 +17,7 @@
   - No imports needed; this is a pure-data module.
   - _Spec: section 2.1_
 
-- [ ] **1.2** Create `sync-ps-to-cc.py` with module path handling and imports
+- [x] **1.2** Create `sync-ps-to-cc.py` with module path handling and imports
   - Create file at `media/linux/ps-queries/sync-ps-to-cc.py`.
   - Add shebang `#!/usr/bin/env python3`.
   - Replicate the `moddir` pattern from `sync-constant-contact.py` (lines 20-32): resolve `'../../../python'`, handle the MS Windows symlink-as-file quirk (read the file contents as the path), insert into `sys.path`.
@@ -32,7 +32,7 @@
   - Add `if __name__ == '__main__': main()` at the bottom.
   - _Spec: sections 8.1, 8.2, 8.3_
 
-- [ ] **1.3** Implement CLI argument parsing with `argparse`
+- [x] **1.3** Implement CLI argument parsing with `argparse`
   - Create a `setup_cli_args()` function that uses standard `argparse.ArgumentParser` (NOT `oauth2client.tools.argparser`).
   - Define arguments:
     - `--ps-api-keyfile` (required): ParishSoft API key file

--- a/specs/sync-ps-to-cc/tasks.md
+++ b/specs/sync-ps-to-cc/tasks.md
@@ -298,32 +298,32 @@
 
 ## Phase 8: Edge Cases and Error Handling
 
-- [ ] **8.1** Verify shared-email handling throughout the pipeline
+- [x] **8.1** Verify shared-email handling throughout the pipeline
   - The `ps_members_by_email` index (task 2.5) naturally collects all PS members sharing an email. Verify:
     - `execute_actions()` passes the full list from `ps_members_by_email[email]` to `CC.create_contact_dict()` so the contact name is derived from ALL members.
     - Set-diff in task 4.2: if ANY member sharing an email is in a workgroup, that email is in `desired_emails[i]`, so the contact is subscribed. This works because `desired_emails` is built from workgroup membership, not from individual members.
     - `detect_name_mismatches()` uses `contact['PS MEMBERS']` (populated by `link_contacts_to_ps_members`), which already contains all members for that email.
   - _Spec: section 7.1_
 
-- [ ] **8.2** Verify email-change scenarios are handled by the diff
+- [x] **8.2** Verify email-change scenarios are handled by the diff
   - Confirm that the set-diff architecture handles these without special code:
     - **Members split emails**: old contact retains some members; new email appears in `emails_needing_contacts` → gets a `create` action. Old contact may get `update_name` action.
     - **Members merge emails**: one contact now maps to multiple members; the other contact loses its PS members → logged as deletion candidate.
   - If any scenario is not handled, add corrective logic. Otherwise, add a comment in the code documenting why it works.
   - _Spec: section 7.2_
 
-- [ ] **8.3** Handle contacts with missing name fields
+- [x] **8.3** Handle contacts with missing name fields
   - Ensure `detect_name_mismatches()` (task 4.3) and any name-display code use `contact.get('first_name', '')` and `contact.get('last_name', '')` since CC contacts can lack these fields.
   - Ensure the `detail` string in actions handles missing names gracefully.
   - _Depends: 4.3_
   - _Spec: section 3.3.6 (step 3)_
 
-- [ ] **8.4** Ensure bulk data loading failures terminate the script
+- [x] **8.4** Ensure bulk data loading failures terminate the script
   - Verify that `CCAPIError` from `CC.api_get_all()` calls (contacts and lists) is NOT caught — it should propagate and terminate the script. Only the `execute_actions()` function catches `CCAPIError` (for individual contact updates).
   - _Depends: 2.2, 5.2_
   - _Spec: section 6.1_
 
-- [ ] **8.5** Ensure config resolution failures terminate the script
+- [x] **8.5** Ensure config resolution failures terminate the script
   - Verify that if a PS Member Workgroup name or CC List name from `SYNCHRONIZATIONS` is not found, the script logs an error and calls `exit(1)`.
   - _Depends: 3.1_
   - _Spec: section 6.3_


### PR DESCRIPTION
Use AI to re-write the ParishSoft --> Constant Contact synchronization.

* Significantly simpler, easier-to-maintain code
* Added several new features:
    * HTML emails (vs. plain text emails)
    * Rename CC Contacts to match the ParishSoft Member names
    * New report email that lists CC Contacts that unsubscribed from CC Lists, and maps back to the ParishSoft Members that need to be removed from specific ParishSoft Member WorkGroups.  This report runs at 2am on Mondays, and gives staff an opportunity to clean up ParishSoft data.
    * Ability (still turned off) to delete CC Contacts that are no longer needed