### PR TITLE
Migration information for moving to ParishKit

### DIFF
--- a/migrate-to-parishkit/README.md
+++ b/migrate-to-parishkit/README.md
@@ -1,0 +1,138 @@
+# Migrate to parishkit
+
+This directory contains operator-facing migration notes, non-secret starter
+configs, and cron-friendly wrappers for replacing the old scripts with the new
+`parishkit` package.
+
+## Install the local package
+
+Build and install from the new repository on the target host:
+
+```sh
+cd /path/to/parishkit
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e '.[google,slack]'
+```
+
+Use the same virtual environment from cron, or install into a dedicated
+system-managed environment.
+
+## Create runtime directories
+
+```sh
+sudo mkdir -p /opt/parishkit/{bin,cache,config,credentials,logs,reports,run}
+sudo chmod 700 /opt/parishkit/credentials
+```
+
+Copy the YAML files from `configs/` to `/opt/parishkit/config/` and edit any
+site-specific IDs or addresses before enabling cron.
+
+## Fresh credentials
+
+ParishSoft:
+
+- Store the read-only API key at
+  `/opt/parishkit/credentials/parishsoft-api-key.txt`.
+- Restrict file permissions to the automation user.
+- Validate with `parishkit` smoke test:
+
+```sh
+parishkit-parishsoft-connectivity \
+  --api-key-file /opt/parishkit/credentials/parishsoft-api-key.txt \
+  --send
+```
+
+Google:
+
+1. Create a fresh Google Cloud project.
+2. Enable Calendar API, Admin SDK API, Groups Settings API, Drive API, and
+   Sheets API as needed by the migrated jobs.
+3. Create service accounts for automation jobs that support domain-wide
+   delegation.
+4. Enable domain-wide delegation on each service account and record the client
+   ID.
+5. In Google Workspace Admin, authorize the client ID for the scopes shown in
+   the relevant script README files.
+6. Create and store service account JSON keys under
+   `/opt/parishkit/credentials/`.
+7. For OAuth-user flows, configure the OAuth consent screen and OAuth client,
+   then use `scripts/smoke-tests/google-api.py --bootstrap-user-token` from the
+   `parishkit` repo to generate token files.
+8. Store all generated tokens under `/opt/parishkit/credentials/`.
+
+Constant Contact:
+
+- Create a Constant Contact app/client and store the client JSON at
+  `/opt/parishkit/credentials/constant-contact-client.json`.
+- Run the documented device OAuth smoke tool from the `parishkit` repo and
+  store the token JSON at
+  `/opt/parishkit/credentials/constant-contact-token.json`.
+
+Slack:
+
+- Store the Slack bot token at `/opt/parishkit/credentials/slack-token.txt`.
+- Configure `slack.token_file`, `slack.channel`, and `slack.level` in any job
+  config that should send critical log notifications.
+
+## Credential shortcut
+
+If the old host already has known-good credentials, the operator may copy them
+to `/opt/parishkit/credentials/` as a migration shortcut. Do not commit copied
+credential files. Run the smoke tests before enabling cron.
+
+## Cron changes
+
+Replace old cron entries that invoke:
+
+- `media/linux/calendar-reservations/run.sh`
+- `media/linux/ps-queries/create-ministry-rosters.py`
+- `media/linux/ps-queries/sync-google-group.py`
+- `media/linux/ps-queries/sync-ps-to-cc.py`
+
+with the wrappers in `wrappers/`. The wrappers call the new `pk-*` commands
+and use matching `/opt/parishkit/config/pk-*.yaml` files.
+
+Wrapper and config pairs:
+
+- `pk-cron-runner` uses `/opt/parishkit/config/pk-cron-runner.yaml` to run
+  the migrated scheduled jobs with one shared lock and runner log.
+- `wrappers/pk-validate-gcalendar-reservations.sh`
+  uses `/opt/parishkit/config/pk-validate-gcalendar-reservations.yaml`.
+- `wrappers/pk-create-ps-ministry-rosters.sh`
+  uses `/opt/parishkit/config/pk-create-ps-ministry-rosters.yaml`.
+- `wrappers/pk-sync-ps-to-ggroup.sh`
+  uses `/opt/parishkit/config/pk-sync-ps-to-ggroup.yaml`.
+- `wrappers/pk-sync-ps-to-cc.sh`
+  uses `/opt/parishkit/config/pk-sync-ps-to-cc.yaml`.
+
+Example:
+
+```cron
+*/10 * * * * /path/to/old-repo/migrate-to-parishkit/wrappers/pk-validate-gcalendar-reservations.sh
+```
+
+Or run the migrated jobs through one runner config. Schedule roster generation
+once a day at 2am, and run the sync/validation jobs every 15 minutes on an
+offset so the two runner invocations do not start at the same time:
+
+```cron
+5,20,35,50 * * * * pk-cron-runner --config /opt/parishkit/config/pk-cron-runner.yaml pk-sync-ps-to-ggroup pk-sync-ps-to-cc pk-validate-gcalendar-reservations
+0 2 * * * pk-cron-runner --config /opt/parishkit/config/pk-cron-runner.yaml pk-create-ps-ministry-rosters
+```
+
+To run only selected jobs from that config, pass their job names after the
+config path:
+
+```sh
+pk-cron-runner --config /opt/parishkit/config/pk-cron-runner.yaml \
+  pk-create-ps-ministry-rosters \
+  pk-sync-ps-to-ggroup \
+  pk-sync-ps-to-cc \
+  pk-validate-gcalendar-reservations
+```
+
+Run each wrapper manually with `--dry-run` first, review logs under
+`/opt/parishkit/logs/`, then remove the dry-run override from cron if the job is
+expected to write.

--- a/migrate-to-parishkit/configs/pk-create-ps-ministry-rosters.yaml
+++ b/migrate-to-parishkit/configs/pk-create-ps-ministry-rosters.yaml
@@ -1,0 +1,262 @@
+common:
+  dry_run: false
+  timezone: America/Kentucky/Louisville
+
+logging:
+  log_dir: /opt/parishkit/logs
+
+slack:
+  token_file: /opt/parishkit/credentials/slack-token.txt
+  channel: "#bot-errors"
+  level: ERROR
+
+parishsoft:
+  api_key_file: /opt/parishkit/credentials/parishsoft-api-key.txt
+  cache_dir: /opt/parishkit/cache/parishsoft
+  cache_limit: 14m
+  expected_organization: Epiphany Catholic Church
+
+google:
+  service_account_file: /opt/parishkit/credentials/google-service-account.json
+  delegated_subject: itadmin@epiphanycatholicchurch.org
+
+rosters:
+  workgroup_leader_suffix: " Ldr"
+  ministries:
+    - ministry: "100-Parish Pastoral Council"
+      spreadsheet_id: "1aIoStpSOsup8XL5eNd8nhpJwM-IqN2gTkwVf_Qvlylc"
+      include_birthday: false
+    - ministry: "102-Finance Advisory Council"
+      spreadsheet_id: "1oGkjyLDexQyb-z53n2luFpE9vU7Gxv0rX6XirtxSjA0"
+      include_birthday: false
+    - ministry: "103-Worship Committee"
+      spreadsheet_id: "1h_ZvhkYlnebIu0Tk7h1ldJo-VKnJsJGe1jEzY34mcd0"
+      include_birthday: false
+    - ministry: "104-Stewardship Team"
+      spreadsheet_id: "1avaHrl-sHOWOc541GclHZL3ajG30HozISR0HDoswKnM"
+      include_birthday: false
+    - ministry: "107-Social Resp Steering Comm"
+      spreadsheet_id: "1Am3v0Pv4D9zubkGYgFbUd8e92PZnBPrbcwKrMrs8AnI"
+      include_birthday: false
+    - ministry: "108-Faith Formation Team"
+      spreadsheet_id: "1rWy81dH5ZSdjfXGyFN6nF9DIkVk1NS5G7RmHZDn5FTY"
+      include_birthday: false
+    - ministry: "110-Ten Percent Committee"
+      spreadsheet_id: "18BIrnBWf_4LS9XeC9tordSD1SBgJz67a0I9Ouj6ZcEc"
+      include_birthday: false
+    - ministry: "111-Hispanic Ministry Team"
+      spreadsheet_id: "1FuUzKKmezkfBcBJdGiX1gbw4PHmqR_nivwAjoFTLjK8"
+      include_birthday: false
+    - ministry: "113-Media Comms Planning Comm."
+      spreadsheet_id: "1erlqkK_F-ol8Bmo5Pg6SoAe355tOxwU3D4pU179foCU"
+      include_birthday: false
+    - ministry: "115-Community Care Committee"
+      spreadsheet_id: "1bKiNztcE20jrK24ccoCzOJDuJsA-nAR-P-6BYstIDog"
+      include_birthday: false
+    - ministry: "116-Youth Council"
+      spreadsheet_id: "1dM3gNsnTJyQDLeRSmP1iRhjWlXV0aHiOCmdLtG3KnKc"
+      include_birthday: false
+    - ministry: "200-Audit Committee"
+      spreadsheet_id: "1OJ3z9tS9qoZMjr4EfSh5zeKy_PKmaRja9htIthjUPpI"
+      include_birthday: false
+    - ministry: "201-Collection Counter"
+      spreadsheet_id: "1w-PQ-_jnzWWRB3id-Mh4pNHTHJzf9Al1gc_p7cS0koM"
+      include_birthday: false
+    - ministry: "203-Garden & Grounds"
+      spreadsheet_id: "1ZrJCRCrrClQuEq9KPXiRVj2s2u78L6R4-P7hbMpYqzs"
+      include_birthday: false
+    - ministry: "204-Parish Office Volunteers"
+      spreadsheet_id: "1yhGeBNaUTuVkEGTRkCh5SC6hQLOpdaEVNpXaq2WmMc4"
+      include_birthday: false
+    - ministry: "206-Space Arrangers"
+      spreadsheet_id: "1ZIAn7MdeDVcgvHwR98dXs_ewIaU2uWbl6mvriLSk5V0"
+      include_birthday: false
+    - ministry: "207-Technology Committee"
+      spreadsheet_id: "1Gn2m2VMabPkWJWg_NTs6XeGPf_Qi7qPELLxyOx9Q0vU"
+      include_birthday: false
+    - ministry: "208-Weekend Closer"
+      spreadsheet_id: "1pj2r_0Xjog22g-kiSmSGkO6BHIIZqW7uXcE3hUs6Xy8"
+      include_birthday: false
+    - ministry: "300-Art & Environment"
+      spreadsheet_id: "1uXy2zTQeeH_YtBAR46lDV5X8ADZRgPnNROtzDU_iqv0"
+      include_birthday: false
+    - ministry: "301-Audio/Visual/Light Minstry"
+      spreadsheet_id: "1LtsNJc-9KYZkQqy2BITQ4Xgd_ns4Uo7z3YSQdnQrzN8"
+      include_birthday: false
+    - ministry: "303-Linens/Vestments Ministry"
+      spreadsheet_id: "1ul5doCFZx4Y_L8ZNmDarVdgLy_dQo2MkE0mdo5kbrY0"
+      include_birthday: false
+    - ministry: "304-LiturgicalPlanningDscrnmnt"
+      spreadsheet_id: "11A59wLOy58-ADKm60YuVGDG0N02E8a9iY-VoCjQX9tY"
+      include_birthday: false
+    - ministry: "306-Music Support for Children"
+      spreadsheet_id: "1ODBCOAUY5g93-ZDrgAx9-Fv5wT4VSeMYxHgpFeb2F4s"
+      include_birthday: false
+    - ministry: "307-Wedding Assistant"
+      spreadsheet_id: "1UBzQOEpdYmb1afAnrPDlQcz0hoouvd6mkpEV6rYDMxg"
+      include_birthday: false
+    - ministry: "308-Worship&Music Support Team"
+      spreadsheet_id: "1kHRnohAEeaC_2-yTTcgHe36yRVJ4EhWhmbBCZ0P_vI8"
+      include_birthday: false
+    - ministry: "309-Acolytes"
+      spreadsheet_id: "1zXfAxnuQCATWQ7nU7QYn2Mvy1Ql1Huy7Ve1DW60nPKA"
+      include_birthday: false
+    - ministry: "310-Adult Choir"
+      spreadsheet_id: "1ku8Aq9dXm_mrOq421MWVk7hAqV2Am5FFSgUACOYs2WU"
+      include_birthday: false
+    - ministry: "311-Bell Choir"
+      spreadsheet_id: "1UTzXgO9ZLBHB0w-zAW8-u57cgWLbkWWGanJgPC9gboE"
+      include_birthday: true
+    - ministry: "312-Children's Music Ministry"
+      spreadsheet_id: "11H5SbDti8Jm2HMqdo3mZ3_5iTBky4OmZGdB_WeCOZYI"
+      include_birthday: false
+    - ministry: "313-Eucharistic Ministers"
+      spreadsheet_id: "10Aq9XtZHL3v0m0Erm71f8BSUYr7CiEDMwzDWTSgKPJ4"
+      include_birthday: false
+    - ministry: "315-Funeral Mass Ministry"
+      spreadsheet_id: "107rbGV_WbEz6m6m8XMliLWIMFKKMz8pQv8pdjgLFvLI"
+      include_birthday: false
+    - ministry: "316-Greeters"
+      spreadsheet_id: "1vd7sltcU8MVwIBad__PyXXMN_cUEFvdXpL5RkYiBWJ0"
+      include_birthday: false
+    - ministry: "317-Instrumentalists & Cantors"
+      spreadsheet_id: "1YP3sC4dcOWH9Li1rJV8D5FI9mef50xvxqOf6K1K54_U"
+      include_birthday: true
+    - ministry: "318-Lectors"
+      spreadsheet_id: "1X796X7_wFZmYoKMzGnj2BFFCOeoncIEILv1cmq_CJB8"
+      include_birthday: false
+    - ministry: "319-Liturgical Dance Ministry"
+      spreadsheet_id: "14s4gtJMjK0qiHvN-eQ1zaD76PoSGVd9qcfIPxTDGhrc"
+      include_birthday: false
+    - ministry: "401-Epiphany Companions"
+      spreadsheet_id: "1voFdTbY3RMs3R_X-pO6-hbjBfC9Prm80ON-lLDTl2UI"
+      include_birthday: false
+    - ministry: "404-Welcome Desk"
+      spreadsheet_id: "1pJwD2UXiDAKng-DFwdWMp0AbZQFSJoiOsJaQgJmfvCE"
+      include_birthday: false
+    - ministry: "409-Sunday Morning Coffee"
+      spreadsheet_id: "1zaVGPdnHp5zZu3zbWfGckIaxbCeCSSTYyoe4pCIlQjs"
+      include_birthday: false
+    - ministry: "412-Sages (for 50 yrs. +)"
+      spreadsheet_id: "11LCDr-Vc3jyeKh5nrd49irscdvTv3TDXhpOoFWlohgs"
+      include_birthday: false
+    - ministry: "413-Singles Explore Life (SEL)"
+      spreadsheet_id: "1-uvQO5RRf0K6NJlR_4Mijygn4XGk0zhvowdflKLoEUc"
+      include_birthday: false
+    - ministry: "414-Hospitality Linen Ministry"
+      spreadsheet_id: "1speD5aJbcLc0hugyfhP8J1vhrFeHYO3-Zpuc77GQBjM"
+      include_birthday: false
+    - ministry: "500-Bereavement Receptions"
+      spreadsheet_id: "17QXoqgreLu8sUQpZfooNkto4NV06wdoE3yA6Q5vgiAw"
+      include_birthday: false
+      role_sheets:
+        - name: "500-Bereavement Receptions: Team 1"
+          roles:
+            - "Staff"
+            - "Chairperson"
+            - "Team 1 Leader"
+            - "Team 1 Member"
+            - "Team Member: Both"
+          spreadsheet_id: "1UKk8-zsi4m1i271-SbM4UhkREs0dYcZSpmwGsV7m9rQ"
+        - name: "500-Bereavement Receptions: Team 2"
+          roles:
+            - "Staff"
+            - "Chairperson"
+            - "Team 2 Leader"
+            - "Team 2 Member"
+            - "Team Member: Both"
+          spreadsheet_id: "1XGvOa98piwKa05yYUIWXIXGXyMHNYSYPMAyvwwSl28A"
+    - ministry: "501-Eucharist to Sick&Homebnd"
+      spreadsheet_id: "1KkCF2V4JIK65b9QsfSG-lGMCASXPavxIxim-CfzxBYk"
+      include_birthday: false
+    - ministry: "505-Healing Blanket Ministry"
+      spreadsheet_id: "1fKXe-NuoObjgYoFRcbuJQwIOjFIAfT7TQB87eccgfng"
+      include_birthday: false
+    - ministry: "507-Flower Angels"
+      spreadsheet_id: "1GslfFYPsXPGk16N9Oq6wx8l2HeZNryIBu29lFuLITck"
+      include_birthday: false
+    - ministry: "508-Grief Support Group"
+      spreadsheet_id: "1NOijo2AHwftLBGDyCiyGMEIp4Qmfw-0jVjHG9Ygz3S8"
+      include_birthday: false
+    - ministry: "509-HOPE for the Widowed Support Groups"
+      spreadsheet_id: "1Ua7pm-4Av7vPhU8quL5sAEKfowo8O_jfEF34vD1s3Wg"
+      include_birthday: false
+    - ministry: "510-Flower Delivery to SHB"
+      spreadsheet_id: "160CPnzR_Q-kph_36LLCPFMC_pLRdMFbUQ2fkQ90LEw0"
+      include_birthday: false
+    - ministry: "700-Advocates for Common Good"
+      spreadsheet_id: "1r6FNXGn-T5anj9X7HGlB2EpZ9oXfy5dQXD6z-OQEGgE"
+      include_birthday: false
+    - ministry: "701-CLOUT"
+      spreadsheet_id: "1k_hH1tEWBGuERCmFvhZxKOfAsBkqy0uZ16LAd0_jMDg"
+      include_birthday: false
+    - ministry: "703-Eyeglass Ministry"
+      spreadsheet_id: "1Iz8hz7NAhh9-dVMiC7mL8yYFi_qmM_ayB5IXhJU0uPw"
+      include_birthday: false
+    - ministry: "704-Habitat for Humanity"
+      spreadsheet_id: "1gBQXnTgxodILkjXvBrfJ-sztVj6NZaZQI1kbddAESNE"
+      include_birthday: false
+    - ministry: "705-Hunger & Poverty Ministry"
+      spreadsheet_id: "1i3EBKO3Lj3lIprhnoc4VeabEIPAuce5JeV99y1zrUAc"
+      include_birthday: false
+    - ministry: "706-Prison Ministry"
+      spreadsheet_id: "1HacDJsMK-oLKjuPjvrABhbYn-b0joox3GMY9uEA--yg"
+      include_birthday: false
+    - ministry: "707-St. Vincent De Paul"
+      spreadsheet_id: "1m0Cp7k0XyeJvZ8Z0IZXrudD3oALfeLr0sWvvnEEgn0o"
+      include_birthday: false
+    - ministry: "708-Social Concerns Forum"
+      spreadsheet_id: "1rT8JyEELbazL2scZZP4glt-ZVyK2v3Nn-Rr9rtuhmhU"
+      include_birthday: false
+    - ministry: "709-Twinning Committee:Chiapas"
+      spreadsheet_id: "1lXkeHsyHNqHYH4zs_HiQdaq8PK8vh5W2koQE5sCq_7U"
+      include_birthday: false
+    - ministry: "710-Creation Care Team"
+      spreadsheet_id: "1tFmzvu53v-oBF3P59fl4zv46VHt4PRu066YyceuYNl4"
+      include_birthday: false
+    - ministry: "711-Women's Concerns Committee"
+      spreadsheet_id: "1t-pu0efeZbLgnLiRQXgIf_MPZA06-CXiY5k9h0qkXI8"
+      include_birthday: false
+    - ministry: "800-Catechists for Children"
+      spreadsheet_id: "1jsoRxugVwXi_T2IDq9J-mEVdzS8xaOk9kuXGAef-YaQ"
+      include_birthday: false
+    - ministry: "802-Gather the Children Prayer Leaders"
+      spreadsheet_id: "1SqqnAFEZlUdCAxp6NYKqpqGFy13L_aheVEGzHLLzOuk"
+      include_birthday: false
+    - ministry: "805-Monday Adult Bible Study Catechists"
+      spreadsheet_id: "1rBKiweOBT-JZFbfv5Sf4_vjjOlAYnOGaZIhadtBPxSE"
+      include_birthday: false
+    - ministry: "807-Catechumenate / Initiation Team Members"
+      spreadsheet_id: "1lI9eO0bryD6GFIsgJ5FipGePK4FaJ7v8eIp71DFz_6A"
+      include_birthday: false
+    - ministry: "808-BibleTimes Volunteers"
+      spreadsheet_id: "1gANQt7PBc8erErQRHrRLtkdmOF3Y7DbuLC3J6aRLu4U"
+      include_birthday: false
+    - ministry: "901-Youth Ministry Adult Vols"
+      spreadsheet_id: "13neLXFrDTsohe_N_CVPX7ajx4pFvYb9miFtZtUqdVl4"
+      include_birthday: false
+    - ministry: "902-Adult Advisory Council"
+      spreadsheet_id: "1yW9tUxef7slTboXYXlVoWrAH80vhP-IAZ53MBjXYUPA"
+      include_birthday: false
+    - ministry: "903-Confirmation Core Team"
+      spreadsheet_id: "1Ay9Zp3HnHmINygZWIilVWMvlbD4IfKygyOoa9wU4FK8"
+      include_birthday: false
+    - ministry: "E-Taize Prayer"
+      spreadsheet_id: "1Sz6tRzQ7q8sqN9tjaq3wX2lpE7aWi9-bNyyooDebmt4"
+      include_birthday: false
+    - ministry: "E-Soul Life"
+      spreadsheet_id: "14txmxfY_gacwdusNQJMM8SwNiHnshCxPJZc7leD4X2Q"
+      include_birthday: false
+  workgroups:
+    - workgroup: "Livestream Team"
+      spreadsheet_id: "1Yku0IFuIKZCeUNGB5c_Ser_geYkylC2o1tiVfaNwkx8"
+      include_birthday: false
+    - workgroup: "YouthMin parent: Jr high"
+      spreadsheet_id: "1VIs-AezopoWd3rpVU_kqMOTTXlBPpjI9IxAbhDpSnG4"
+      include_birthday: false
+    - workgroup: "YouthMin parent: Sr high"
+      spreadsheet_id: "1B_2LeR0EbG3oDUqifvB51YhCuj30lhaYHfUb9bmCj5A"
+      include_birthday: false
+    - workgroup: "Movers"
+      spreadsheet_id: "1q0rNZQ0Od3cCoFG2qLgKZep10GzQ3nmvVIIJuUOWBgY"
+      include_birthday: false

--- a/migrate-to-parishkit/configs/pk-cron-runner.yaml
+++ b/migrate-to-parishkit/configs/pk-cron-runner.yaml
@@ -1,0 +1,65 @@
+# Cron-friendly runner config for Epiphany's migrated parishkit jobs.
+#
+# Copy this file to /opt/parishkit/config/pk-cron-runner.yaml and adjust paths
+# if parishkit is installed somewhere other than /opt/parishkit.
+
+lock:
+  # Prevent overlapping full-runner invocations.
+  path: /opt/parishkit/run/pk-cron-runner.lock
+  # A normal run should finish well under this; if not, alert instead of
+  # silently starting a second copy.
+  stale_after: 30m
+  stale_action: exit-and-alert
+
+logging:
+  # Runner logs are JSON Lines; child commands write their own logs according
+  # to their individual configs.
+  log_file: /opt/parishkit/logs/pk-cron-runner.log
+
+slack:
+  token_file: /opt/parishkit/credentials/slack-token.txt
+  channel: "#bot-errors"
+  level: ERROR
+  notify_success: false
+  context: Epiphany ParishKit runner
+
+runner:
+  stop_on_first_failure: true
+  context: Epiphany ParishKit runner
+
+jobs:
+  - name: ministry-rosters
+    enabled: true
+    cwd: /opt/parishkit
+    timeout: 5m
+    command:
+      - pk-create-ps-ministry-rosters
+      - --config
+      - /opt/parishkit/config/pk-create-ps-ministry-rosters.yaml
+
+  - name: ps-to-google-groups
+    enabled: true
+    cwd: /opt/parishkit
+    timeout: 5m
+    command:
+      - pk-sync-ps-to-ggroup
+      - --config
+      - /opt/parishkit/config/pk-sync-ps-to-ggroup.yaml
+
+  - name: ps-to-cc
+    enabled: true
+    cwd: /opt/parishkit
+    timeout: 5m
+    command:
+      - pk-sync-ps-to-cc
+      - --config
+      - /opt/parishkit/config/pk-sync-ps-to-cc.yaml
+
+  - name: validate-google-calendar
+    enabled: true
+    cwd: /opt/parishkit
+    timeout: 5m
+    command:
+      - pk-validate-gcalendar-reservations
+      - --config
+      - /opt/parishkit/config/pk-validate-gcalendar-reservations.yaml

--- a/migrate-to-parishkit/configs/pk-sync-ps-to-cc.yaml
+++ b/migrate-to-parishkit/configs/pk-sync-ps-to-cc.yaml
@@ -1,0 +1,66 @@
+common:
+  dry_run: false
+  timezone: America/Kentucky/Louisville
+
+logging:
+  log_dir: /opt/parishkit/logs
+
+slack:
+  token_file: /opt/parishkit/credentials/slack-token.txt
+  channel: "#bot-errors"
+  level: ERROR
+
+parishsoft:
+  api_key_file: /opt/parishkit/credentials/parishsoft-api-key.txt
+  cache_dir: /opt/parishkit/cache/parishsoft
+  cache_limit: 14m
+  expected_organization: Epiphany Catholic Church
+
+constant_contact:
+  client_id_file: /opt/parishkit/credentials/constant-contact-client.json
+  access_token_file: /opt/parishkit/credentials/constant-contact-token.json
+
+email:
+  provider: google-workspace
+  service_account_file: /opt/parishkit/credentials/google-service-account.json
+  delegated_user: no-reply@epiphanycatholicchurch.org
+
+sync:
+  notifications:
+    sender: no-reply@epiphanycatholicchurch.org
+  update_names: true
+  # Keep this enabled for normal operations: it moves detailed filtered-
+  # unsubscribed-contact tables into the scheduled report. If disabled, those
+  # tables are included in regular sync update emails, and a run with no
+  # Constant Contact changes can still send an email only about filtered
+  # unsubscribed contacts.
+  unsubscribed_report:
+    enabled: true
+    day_of_week: monday
+    time: "02:00"
+    window_minutes: 14
+    # Records the last local date for which the report was sent.
+    state_file: /opt/parishkit/run/pk-sync-ps-to-cc-unsubscribed-report.json
+
+  lists:
+    - source_workgroup: CC SYNC Daily Gospel Reflections
+      target_list: PS SYNC Daily Gospel Reflections
+      notifications:
+        - ps-constantcontact-sync@epiphanycatholicchurch.org
+        - director-communications@epiphanycatholicchurch.org
+        - business-manager@epiphanycatholicchurch.org
+    - source_workgroup: CC SYNC Epiphany Happenings
+      target_list: PS SYNC Epiphany Happenings
+      notifications:
+        - ps-constantcontact-sync@epiphanycatholicchurch.org
+        - director-communications@epiphanycatholicchurch.org
+    - source_workgroup: CC SYNC Obituaries
+      target_list: PS SYNC Obituaries
+      notifications:
+        - ps-constantcontact-sync@epiphanycatholicchurch.org
+        - director-communications@epiphanycatholicchurch.org
+    - source_workgroup: CC SYNC Weekday Mass
+      target_list: PS SYNC Weekday Mass
+      notifications:
+        - ps-constantcontact-sync@epiphanycatholicchurch.org
+        - director-communications@epiphanycatholicchurch.org

--- a/migrate-to-parishkit/configs/pk-sync-ps-to-ggroup.yaml
+++ b/migrate-to-parishkit/configs/pk-sync-ps-to-ggroup.yaml
@@ -1,0 +1,737 @@
+common:
+  dry_run: false
+  timezone: America/Kentucky/Louisville
+
+logging:
+  log_dir: /opt/parishkit/logs
+
+slack:
+  token_file: /opt/parishkit/credentials/slack-token.txt
+  channel: "#bot-errors"
+  level: ERROR
+
+parishsoft:
+  api_key_file: /opt/parishkit/credentials/parishsoft-api-key.txt
+  cache_dir: /opt/parishkit/cache/parishsoft
+  cache_limit: 14m
+  expected_organization: Epiphany Catholic Church
+
+google:
+  service_account_file: /opt/parishkit/credentials/google-service-account.json
+  delegated_subject: itadmin@epiphanycatholicchurch.org
+
+email:
+  provider: google-workspace
+  service_account_file: /opt/parishkit/credentials/google-service-account.json
+  delegated_user: no-reply@epiphanycatholicchurch.org
+
+sync:
+  google_mail_domains:
+    - gmail.com
+    - epiphanycatholicchurch.org
+  notifications:
+    sender: no-reply@epiphanycatholicchurch.org
+  groups:
+    - group: "ppc@epiphanycatholicchurch.org"
+      notify:
+        - "administrative-assistant@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "100-Parish Pastoral Council"
+    - group: "administration-committee@epiphanycatholicchurch.org"
+      notify:
+        - "business-manager@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "102-Finance Advisory Council"
+    - group: "worship-committee@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "103-Worship Committee"
+    - group: "stewardship@epiphanycatholicchurch.org"
+      notify:
+        - "director-parish-engagement@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "104-Stewardship Team"
+    - group: "social-responsibility-steering-commitee@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-social-resp@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "107-Social Resp Steering Comm"
+    - group: "ten-percent-committee@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-social-resp@epiphanycatholicchurch.org"
+        - "ten-percent-chair@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "110-Ten Percent Committee"
+    - group: "ten-percent-treasurer@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-social-resp@epiphanycatholicchurch.org"
+        - "ten-percent-chair@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Ten Percent Treasurer"
+    - group: "ten-percent-ad-hoc-committee@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-social-resp@epiphanycatholicchurch.org"
+        - "ten-percent-chair@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Ten Percent ad hoc committee"
+    - group: "hispanic-ministry-team@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-social-resp@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "111-Hispanic Ministry Team"
+    - group: "communications-planning-team@epiphanycatholicchurch.org"
+      notify:
+        - "director-communications@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "113-Media Comms Planning Comm."
+    - group: "garden-and-grounds@epiphanycatholicchurch.org"
+      notify:
+        - "business-manager@epiphanycatholicchurch.org"
+        - "emswine2@gmail.com"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "203-Garden & Grounds"
+    - group: "tech-committee@epiphanycatholicchurch.org"
+      notify:
+        - "business-manager@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "207-Technology Committee"
+    - group: "art-and-environment-ministry@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "300-Art & Environment"
+    - group: "audio-visual-lighting-ministry@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "301-Audio/Visual/Light Minstry"
+    - group: "worship-liturgical-planning-discernment@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "304-LiturgicalPlanningDscrnmnt"
+    - group: "acolytes@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "309-Acolytes"
+    - group: "choir@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "director-choir@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "310-Adult Choir"
+    - group: "bell-ringers@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "311-Bell Choir"
+      workgroups:
+        - "Bell choir email list"
+    - group: "eucharistic-ministers@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "tonya@cabral.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "313-Eucharistic Ministers"
+    - group: "funeral-mass-ministry@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "315-Funeral Mass Ministry"
+    - group: "greeters@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "316-Greeters"
+    - group: "musicians@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "317-Instrumentalists & Cantors"
+      workgroups:
+        - "Musicians email list"
+    - group: "lectors@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "318-Lectors"
+    - group: "prayer-chain-ministry@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "511-Prayer Chain Ministry"
+    - group: "worship-music-assistant@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Worship Music Assistant"
+    - group: "welcome-desk@epiphanycatholicchurch.org"
+      notify:
+        - "director-parish-engagement@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "404-Welcome Desk"
+    - group: "stewardship-name-badges-google-drive-access@epiphanycatholicchurch.org"
+      notify:
+        - "director-parish-engagement@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Name Badges Google Drive acces"
+    - group: "bereavement-receptions@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-parish-life@epiphanycatholicchurch.org"
+        - "bereavement-receptions-chair@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "500-Bereavement Receptions"
+    - group: "care-for-the-sick@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-parish-life@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "501-Eucharist to Sick&Homebnd"
+    - group: "healing-blankets-ministry@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-parish-life@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "505-Healing Blanket Ministry"
+    - group: "grief-support-group@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-parish-life@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "508-Grief Support Group"
+    - group: "women-of-hope-support-groups@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-parish-life@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "509-HOPE for the Widowed Support Groups"
+    - group: "sages@epiphanycatholicchurch.org"
+      notify:
+        - "joanhagedorn46@gmail.com"
+        - "pastoral-associate-parish-life@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "412-Sages (for 50 yrs. +)"
+    - group: "sel@epiphanycatholicchurch.org"
+      notify:
+        - "justlmw@att.net"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "413-Singles Explore Life (SEL)"
+    - group: "advocates-for-the-common-good@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-social-resp@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "700-Advocates for Common Good"
+    - group: "svdpconference@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-social-resp@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "707-St. Vincent De Paul"
+    - group: "twinning-committee@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-social-resp@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "709-Twinning Committee:Chiapas"
+    - group: "creation-care-team@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-social-resp@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "710-Creation Care Team"
+    - group: "childrens-formation-catechists@epiphanycatholicchurch.org"
+      notify:
+        - "formation@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "800-Catechists for Children"
+    - group: "gather-the-children@epiphanycatholicchurch.org"
+      notify:
+        - "formation@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "802-Gather the Children Prayer Leaders"
+    - group: "rcia-team@epiphanycatholicchurch.org"
+      notify:
+        - "formation@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "807-Catechumenate / Initiation Team Members"
+    - group: "bibletimes-core-team@epiphanycatholicchurch.org"
+      notify:
+        - "bibletimes-chair@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "808-BibleTimes Volunteers"
+    - group: "confirmation-core@epiphanycatholicchurch.org"
+      notify:
+        - "youth-minister@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "903-Confirmation Core Team"
+    - group: "livestream-team@epiphanycatholicchurch.org"
+      notify:
+        - "director-communications@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Livestream Team"
+    - group: "livestream-video-upload@epiphanycatholicchurch.org"
+      notify:
+        - "director-communications@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Livestream Video Upload"
+    - group: "movers@epiphanycatholicchurch.org"
+      notify:
+        - "business-manager@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Movers"
+    - group: "taizeprayer@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "E-Taize Prayer"
+    - group: "soullife@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      ministries:
+        - "E-Soul Life"
+    - group: "zoom@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Zoom license"
+    - group: "apply@epiphanycatholicchurch.org"
+      notify:
+        - "business-manager@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Apply@ECC email list"
+    - group: "registration@epiphanycatholicchurch.org"
+      notify:
+        - "business-manager@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Registration@ECC email list"
+    - group: "renovations@epiphanycatholicchurch.org"
+      notify:
+        - "business-manager@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Renovations@ECC email list"
+    - group: "worship-liturgy-plans-editor@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "ECC Liturgy Plans editor"
+    - group: "worship-liturgy-planning-leadership@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Liturgy Planning Ldr"
+    - group: "worship-liturgy-planning-reader@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "ECC Liturgy Plans reader"
+    - group: "worship-liturgy-participation-materials@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "ECC Liturgy Particption Editor"
+    - group: "music-ministry-musicians-information-editor@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "ECC Musicians Info editor"
+    - group: "music-ministry-sheet-music-access@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "ECC Sheet Music access"
+    - group: "mp3-uploads-group@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "business-manager@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Homebound MP3 Recordings"
+    - group: "ministry-homebound-liturgy-recipients@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Homebound recipients email lst"
+        - "Homebound MP3 Recordings"
+    - group: "liturgy-transcriptions@epiphanycatholicchurch.org"
+      notify:
+        - "business-manager@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Liturgy Transcriptions"
+    - group: "maintenance-staff@epiphanycatholicchurch.org"
+      notify:
+        - "business-manager@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Staff: Maintenance"
+    - group: "office-group@epiphanycatholicchurch.org"
+      notify:
+        - "business-manager@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Office@ECC email list"
+    - group: "pastoral-staff@epiphanycatholicchurch.org"
+      notify:
+        - "business-manager@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Staff: Pastoral"
+    - group: "ppc-exec@epiphanycatholicchurch.org"
+      notify:
+        - "pastor@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "PPC Executive Committee"
+    - group: "ppc-assistant@epiphanycatholicchurch.org"
+      notify:
+        - "pastor@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "PPC Assistant"
+    - group: "recordings-viewer@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Recordings access"
+    - group: "support-staff@epiphanycatholicchurch.org"
+      notify:
+        - "business-manager@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Staff: Support"
+    - group: "auxiliary-staff@epiphanycatholicchurch.org"
+      notify:
+        - "business-manager@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Staff: Auxiliary"
+    - group: "wedding-ministries@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "wedding-assistant-chair@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Wedding Ministries email list"
+    - group: "worship-administration@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Worship Administration"
+    - group: "healing-blanket-requests@epiphanycatholicchurch.org"
+      notify:
+        - "associate-pastor@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Healing Blanket requests"
+    - group: "youth-ministry-parents-jr-high@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-youth@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "YouthMin parent: Jr high"
+    - group: "youth-ministry-parents-sr-high@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-youth@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "YouthMin parent: Sr high"
+    - group: "spectrum@epiphanycatholicchurch.org"
+      notify:
+        - "business-manager@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Spectrum@ECC email list"
+    - group: "incoming-photos@epiphanycatholicchurch.org"
+      notify:
+        - "business-manager@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      workgroups:
+        - "Google Drive Incoming Photos"
+      static_members:
+        - email: "staff@epiphanycatholicchurch.org"
+          leader: false
+    - group: "ministry-chairs@epiphanycatholicchurch.org"
+      notify:
+        - "business-manager@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "all_ministry_chairs"
+          purpose: "Find ministry chairs"
+          ministry_pattern: '^(\d\d\d|E-Soul|E-Taize).*'
+          staff_owner_domains:
+            - "epiphanycatholicchurch.org"
+            - "ecclou.org"
+            - "archlou.org"
+    - group: "worship-chair@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_chair"
+          purpose: "Worship ministry chair"
+          ministry_prefix: "103"
+    - group: "ten-percent-chair@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-social-resp@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_chair"
+          purpose: "Ten percent ministry chair"
+          ministry_prefix: "110"
+    - group: "stewardship-chair@epiphanycatholicchurch.org"
+      notify:
+        - "director-parish-engagement@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_chair"
+          purpose: "Stewardship ministry chair"
+          ministry_prefix: "104-Stewardship"
+    - group: "collection-counters-chair@epiphanycatholicchurch.org"
+      notify:
+        - "business-manager@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_chair"
+          purpose: "Collection counter ministry chair"
+          ministry_prefix: "201"
+    - group: "technology-chair@epiphanycatholicchurch.org"
+      notify:
+        - "business-manager@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_chair"
+          purpose: "Technology ministry chair"
+          ministry_prefix: "207"
+    - group: "worship-art-and-environment-chair@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_chair"
+          purpose: "Worship/art&environment ministry chair"
+          ministry_prefix: "300"
+    - group: "wedding-assistant-chair@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_chair"
+          purpose: "Wedding assistant ministry chair"
+          ministry_prefix: "307"
+    - group: "worship-acolytes-chair@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_chair"
+          purpose: "Worship/acolytes ministry chair"
+          ministry_prefix: "309"
+    - group: "worship-communion-ministers-chair@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_chair"
+          purpose: "Worship/communion ministers ministry chair"
+          ministry_prefix: "313"
+    - group: "worship-greeters-chair@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_chair"
+          purpose: "Worship/greeters ministry chair"
+          ministry_prefix: "316"
+    - group: "worship-lectors-chair@epiphanycatholicchurch.org"
+      notify:
+        - "director-worship@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_chair"
+          purpose: "Worship/lectors ministry chair"
+          ministry_prefix: "318"
+    - group: "companions-chair@epiphanycatholicchurch.org"
+      notify:
+        - "director-parish-engagement@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_chair"
+          purpose: "Epiphany Companions ministry chair"
+          ministry_prefix: "401-Epiphany Companions"
+    - group: "sunday-morning-coffee-chair@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-parish-life@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_chair"
+          purpose: "Sunday morning coffee chair"
+          ministry_prefix: "409"
+    - group: "bereavement-receptions-chair@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-parish-life@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_chair"
+          purpose: "Bereavement receptions: Eucharist ministry chair"
+          ministry_prefix: "500"
+    - group: "bereavement-receptions-team-1@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-parish-life@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_role"
+          purpose: "Bereavement receptions: team 1"
+          ministry_prefix: "500"
+          member_roles:
+            - "Team 1 Member"
+            - "Team Member: Both"
+          leader_roles:
+            - "Staff"
+            - "Chairperson"
+            - "Team 1 Leader"
+    - group: "bereavement-receptions-team-1-leader@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-parish-life@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_role"
+          purpose: "Bereavement receptions: team 1 leader"
+          ministry_prefix: "500"
+          leader_roles:
+            - "Team 1 Leader"
+    - group: "bereavement-receptions-team-2@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-parish-life@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_role"
+          purpose: "Bereavement receptions: team 2"
+          ministry_prefix: "500"
+          member_roles:
+            - "Team 2 Member"
+            - "Team Member: Both"
+          leader_roles:
+            - "Staff"
+            - "Chairperson"
+            - "Team 2 Leader"
+    - group: "bereavement-receptions-team-2-leader@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-parish-life@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_role"
+          purpose: "Bereavement receptions: team 2 leader"
+          ministry_prefix: "500"
+          leader_roles:
+            - "Team 2 Leader"
+    - group: "care-for-the-sick-chair@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-parish-life@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_chair"
+          purpose: "Care for the Sick: Eucharist ministry chair"
+          ministry_prefix: "501"
+    - group: "healing-blankets-chair@epiphanycatholicchurch.org"
+      notify:
+        - "pastoral-associate-parish-life@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_chair"
+          purpose: "Chair: Healing Blankets"
+          ministry_prefix: "505"
+    - group: "sel-chair@epiphanycatholicchurch.org"
+      notify:
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_chair"
+          purpose: "SEL ministry chair"
+          ministry_prefix: "413-Singles Explore Life (SEL)"
+    - group: "bibletimes-chair@epiphanycatholicchurch.org"
+      notify:
+        - "formation@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_chair"
+          purpose: "Bibletimes chair"
+          ministry_prefix: "808"
+    - group: "gather-the-children-chair@epiphanycatholicchurch.org"
+      notify:
+        - "formation@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_chair"
+          purpose: "Gather the Children chair"
+          ministry_prefix: "802"
+    - group: "youth-ministry-adult-volunteers-chair@epiphanycatholicchurch.org"
+      notify:
+        - "youth-minister@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_chair"
+          purpose: "Youth Ministry Adult Volunteers"
+          ministry_prefix: "901"
+    - group: "confirmation-core-chair@epiphanycatholicchurch.org"
+      notify:
+        - "youth-minister@epiphanycatholicchurch.org"
+        - "ps-google-sync@epiphanycatholicchurch.org"
+      selectors:
+        - type: "ministry_chair"
+          purpose: "Confirmation Core Team Chair"
+          ministry_prefix: "903"

--- a/migrate-to-parishkit/configs/pk-validate-gcalendar-reservations.yaml
+++ b/migrate-to-parishkit/configs/pk-validate-gcalendar-reservations.yaml
@@ -1,0 +1,79 @@
+common:
+  dry_run: false
+  timezone: America/Kentucky/Louisville
+
+logging:
+  log_dir: /opt/parishkit/logs
+
+slack:
+  token_file: /opt/parishkit/credentials/slack-token.txt
+  channel: "#bot-errors"
+  level: ERROR
+
+google:
+  service_account_file: /opt/parishkit/credentials/google-service-account.json
+  # JMS This could be a user less than the super admin -- just reads
+  # R/W perms to the relevant google calendars
+  delegated_subject: itadmin@epiphanycatholicchurch.org
+
+calendars:
+  timezone: America/New_York
+  acceptable_domains:
+    - epiphanycatholicchurch.org
+    - churchofepiphany.com
+  calendars:
+    - name: Epiphany Events
+      calendar_id: churchofepiphany.com_9gueg54raienol399o0jtdgmpg@group.calendar.google.com
+      check_conflicts: false
+
+    - name: Kitchen (EH)
+      calendar_id: churchofepiphany.com_2d36363539313732302d343738@resource.calendar.google.com
+      check_conflicts: true
+    - name: Dining Room (EH)
+      calendar_id: churchofepiphany.com_34373539303436353836@resource.calendar.google.com
+      check_conflicts: true
+    - name: Living Room (EH)
+      calendar_id: churchofepiphany.com_37313933333139382d323530@resource.calendar.google.com
+      check_conflicts: true
+    - name: Polycom (EH)
+      calendar_id: c_188am3mlh8ghkjovnmm43cqqhdgla@resource.calendar.google.com
+      check_conflicts: true
+
+    - name: Areas F-H (CC)
+      calendar_id: churchofepiphany.com_2d3336333531363533393538@resource.calendar.google.com
+      check_conflicts: true
+    - name: Areas I-K (CC)
+      calendar_id: churchofepiphany.com_2d33353739373832333731@resource.calendar.google.com
+      check_conflicts: true
+    - name: Coffee Bar Room (CC)
+      calendar_id: churchofepiphany.com_2d38343237303931342d373732@resource.calendar.google.com
+      check_conflicts: true
+    - name: Connector table 1 (CC)
+      calendar_id: churchofepiphany.com_2d3538323334323031353338@resource.calendar.google.com
+      check_conflicts: true
+    - name: Connector table 2 (CC)
+      calendar_id: churchofepiphany.com_2d3538313436353238373034@resource.calendar.google.com
+      check_conflicts: true
+    - name: Commercial Kitchen (CC)
+      calendar_id: churchofepiphany.com_34383131343230342d333531@resource.calendar.google.com
+      check_conflicts: true
+    - name: Service Kitchen (CC)
+      calendar_id: c_18867q9j680j6iodj5ne2gjk6mdc0@resource.calendar.google.com
+      check_conflicts: true
+
+    - name: Worship Space (WC)
+      calendar_id: churchofepiphany.com_33363131333030322d363435@resource.calendar.google.com
+      check_conflicts: true
+    - name: Chapter (WC)
+      calendar_id: churchofepiphany.com_2d3431353233343734323336@resource.calendar.google.com
+      check_conflicts: true
+    - name: Narthex (WC)
+      calendar_id: churchofepiphany.com_3334313632303539343135@resource.calendar.google.com
+      check_conflicts: true
+    - name: Quiet room (WC)
+      calendar_id: churchofepiphany.com_2d36343734343332342d353333@resource.calendar.google.com
+      check_conflicts: true
+
+    - name: Lighthouse
+      calendar_id: churchofepiphany.com_2d38303937383836353134@resource.calendar.google.com
+      check_conflicts: true

--- a/migrate-to-parishkit/wrappers/pk-create-ps-ministry-rosters.sh
+++ b/migrate-to-parishkit/wrappers/pk-create-ps-ministry-rosters.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+set -eu
+exec pk-create-ps-ministry-rosters --config /opt/parishkit/config/pk-create-ps-ministry-rosters.yaml "$@"

--- a/migrate-to-parishkit/wrappers/pk-sync-ps-to-cc.sh
+++ b/migrate-to-parishkit/wrappers/pk-sync-ps-to-cc.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+set -eu
+exec pk-sync-ps-to-cc --config /opt/parishkit/config/pk-sync-ps-to-cc.yaml "$@"

--- a/migrate-to-parishkit/wrappers/pk-sync-ps-to-ggroup.sh
+++ b/migrate-to-parishkit/wrappers/pk-sync-ps-to-ggroup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+set -eu
+exec pk-sync-ps-to-ggroup --config /opt/parishkit/config/pk-sync-ps-to-ggroup.yaml "$@"

--- a/migrate-to-parishkit/wrappers/pk-validate-gcalendar-reservations.sh
+++ b/migrate-to-parishkit/wrappers/pk-validate-gcalendar-reservations.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+set -eu
+exec pk-validate-gcalendar-reservations --config /opt/parishkit/config/pk-validate-gcalendar-reservations.yaml "$@"

--- a/specs/evolve-to-parishkit/spec.md
+++ b/specs/evolve-to-parishkit/spec.md
@@ -1,0 +1,851 @@
+# Evolve Existing Parish Scripts to `parishkit`
+
+## Overview
+
+Create a new GitHub repository named `parishkit` in the
+`epiphany40223` organization. The new repository will contain evolved,
+generalized versions of selected Python scripts from this repository.
+
+The primary goal is to remove Epiphany Catholic Church-specific assumptions
+from reusable code and make the scripts suitable for use by other Catholic
+parishes. Parish-specific behavior, names, domains, Google object IDs,
+ministry mappings, Constant Contact list mappings, credentials, and secrets
+must be supplied at runtime through command-line options and YAML
+configuration files.
+
+The new repository is both:
+
+1. An installable Python package named `parishkit`.
+2. A collection of executable script wrappers, each with its own README and
+   example configuration.
+
+Target runtime: Python 3.12 or newer.
+
+## Repository Name
+
+Repository name: `parishkit`
+
+Python package name: `parishkit`
+
+Preferred CLI naming convention:
+
+- `parishkit-print-member`
+- `parishkit-print-ministries`
+- `parishkit-calendar-reservations`
+- `parishkit-create-ministry-rosters`
+- `parishkit-sync-google-group`
+- `parishkit-sync-ps-to-cc`
+- `parishkit-run`
+
+The repository and package name intentionally avoid references to Epiphany,
+ECC, Louisville, or a specific diocese. The package should be reusable by any
+Catholic parish with compatible ParishSoft, Google Workspace, and related
+services.
+
+## Repository Layout
+
+Use a standard Python source layout:
+
+```text
+README.md
+CLAUDE.md
+AGENTS.md -> CLAUDE.md
+.gitignore
+requirements.txt
+pyproject.toml
+src/parishkit/
+  __init__.py
+  cli.py
+  config.py
+  logging.py
+  runner.py
+  retry.py
+  parishsoft.py
+  constant_contact.py
+  google/
+    __init__.py
+    auth.py
+    calendar.py
+    drive.py
+    groups.py
+    sheets.py
+  email/
+    __init__.py
+    base.py
+    google_workspace.py
+    ms365.py
+scripts/
+  run/
+    README.md
+    parishkit-run.py
+    example-config.yaml
+  print-member/
+    README.md
+    print-member.py
+    example-config.yaml
+  print-ministries/
+    README.md
+    print-ministries.py
+    example-config.yaml
+  calendar-reservations/
+    README.md
+    calendar-reservations.py
+    example-config.yaml
+  create-ministry-rosters/
+    README.md
+    create-ministry-rosters.py
+    example-config.yaml
+  sync-google-group/
+    README.md
+    sync-google-group.py
+    example-config.yaml
+  sync-ps-to-cc/
+    README.md
+    sync-ps-to-cc.py
+    example-config.yaml
+tests/
+.github/workflows/ci.yml
+migrate-to-parishkit/
+  README.md
+  run-*.sh
+```
+
+The exact internal module names can evolve during implementation, but the
+layout should preserve these principles:
+
+- Shared code lives under `src/parishkit`.
+- Script wrappers live under `scripts/<tool-name>/`.
+- Each script directory has its own `README.md`.
+- Example configuration files contain fake or generic sample data only.
+- No `ecc-python-modules` symlink strategy is carried forward.
+- No script should modify `sys.path` to import common code.
+
+The implementation work is expected to create the new repository locally and
+fully populate it. It should also create a `migrate-to-parishkit/` directory in
+the old repository containing cron-friendly wrapper scripts that invoke the new
+`parishkit` commands in place of the old repository scripts.
+
+## Executables
+
+Each script wrapper must:
+
+- Start with `#!/usr/bin/env python3`.
+- Have its executable bit set.
+- Contain minimal logic.
+- Import real implementation code from `parishkit`.
+- Use the common CLI, logging, configuration, retry, and auth helpers.
+
+The package should also expose console entry points via `pyproject.toml`, so
+the tools can be run after installation without referencing the wrapper files
+directly.
+
+## Common CLI Conventions
+
+All tools should use consistent option names and behavior.
+
+Common options:
+
+```text
+--config CONFIG.yaml
+--dry-run
+--verbose
+--debug
+--log-file PATH
+--log-dir PATH
+--slack-token-file PATH
+--slack-channel CHANNEL
+--slack-log-level CRITICAL
+--ps-api-key-file PATH
+--ps-cache-dir PATH
+--ps-cache-limit 14m
+```
+
+Tool-specific options are allowed, but common concepts must use common names.
+
+Rules:
+
+- `--debug` implies verbose logging.
+- `--dry-run` must avoid mutating external systems.
+- CLI options should override config values when both are supplied.
+- Secrets may be provided by file path, environment-variable reference, or
+  another explicit runtime mechanism, but must not be embedded in code or
+  sample config.
+
+## Scheduled Job Runner
+
+Create shared runner/orchestration support for cron-driven scheduled jobs.
+This should carry forward the useful operational ideas from the current
+`media/linux/run-all.py` and `slack/runner.py` scripts, but in a reusable
+`parishkit` form.
+
+The runner should support:
+
+- Lockfile protection to prevent more than one concurrent run.
+- Stale-lock detection.
+- Configurable stale-lock behavior:
+  - exit and alert,
+  - remove stale lock and continue,
+  - or fail closed.
+- Lock metadata that is useful for debugging, such as host, PID, command,
+  start time, and configured timeout.
+- Safe lock cleanup on normal exit and handled exceptions.
+- Top-level logging using `parishkit.logging`.
+- Top-level Slack reporting using the standard Slack handler.
+- Watchdog timeout support for child commands.
+- Capture of child stdout/stderr for logging and optional Slack attachment or
+  message inclusion.
+- Optional Slack notification on success.
+- Optional contextual Slack comments, such as "Linux cron run-all automation".
+- Clear exit codes suitable for cron.
+- Configurable job list in YAML.
+- Optional CLI selection of which configured jobs/executables to run.
+- Optional config-file selection of which jobs are enabled.
+- Default behavior that runs all configured/enabled jobs when no explicit job
+  selection is supplied.
+- Per-job working directory.
+- Per-job environment overrides.
+- Per-job timeout.
+- Per-job enabled/disabled flag.
+- A choice of whether the runner stops on first failure or continues through
+  later jobs and reports a summary.
+
+Recommended console entry point:
+
+```text
+parishkit-run
+```
+
+Recommended wrapper directory:
+
+```text
+scripts/run/
+```
+
+The runner should be able to replace the old pattern where cron calls a shell
+wrapper, which calls `slack/runner.py`, which calls `media/linux/run-all.py`,
+which then calls multiple `run.sh` scripts. Shell wrappers may still exist for
+site-specific deployment convenience, but the lockfile, timeout, logging, and
+Slack behavior should be available from `parishkit-run` itself.
+
+Example runner config shape:
+
+```yaml
+lock:
+  path: /opt/parishkit/run/linux.lock
+  stale_after: 16m
+  stale_action: remove-and-continue
+
+logging:
+  log_file: /opt/parishkit/logs/runner.log
+  rotate: true
+
+slack:
+  token_file: /opt/parishkit/credentials/slack-token.txt
+  channel: "#bot-errors"
+  level: CRITICAL
+  notify_success: false
+
+jobs:
+  - name: sync-google-group
+    enabled: true
+    cwd: /opt/parishkit
+    timeout: 15m
+    command:
+      - parishkit-sync-google-group
+      - --config
+      - /opt/parishkit/config/sync-google-group.yaml
+```
+
+Expected runner selection behavior:
+
+- If no `--config` is supplied, look for a default runner config such as
+  `/opt/parishkit/config/runner.yaml`.
+- If a runner config file is available and no CLI job filter is supplied, run
+  all enabled jobs in the config.
+- If CLI job names are supplied, run only those configured jobs.
+- If config marks jobs disabled, do not run them unless an explicit override is
+  provided and documented.
+- If no runner config file is available and a command is supplied on the CLI,
+  support a simple mode that runs that command under the same lockfile,
+  logging, Slack, and watchdog protections.
+- If no runner config file is available and no command is supplied, exit with a
+  clear configuration error.
+
+Additional runner considerations:
+
+- Prefer an atomic lock implementation. If a dependency is used, keep it small
+  and well maintained.
+- Handle termination signals where practical so lock cleanup is reliable.
+- Avoid shell interpolation by default; commands should preferably be expressed
+  as argument lists.
+- Allow an explicit shell mode only if needed and clearly documented.
+- Do not put secrets directly in runner YAML.
+- Keep scheduling decisions simple. Cron can continue to decide when the
+  top-level runner starts; the runner config can handle lightweight per-job
+  enablement and sequencing.
+
+## Default Runtime Paths
+
+Default runtime file locations may be rooted under `/opt/parishkit`.
+
+Recommended defaults:
+
+```text
+/opt/parishkit/config/
+/opt/parishkit/credentials/
+/opt/parishkit/cache/
+/opt/parishkit/logs/
+/opt/parishkit/run/
+```
+
+Examples:
+
+- Logs default to `/opt/parishkit/logs/`.
+- ParishSoft API key files may default to
+  `/opt/parishkit/credentials/parishsoft-api-key.txt`.
+- Google service account JSON files may default to
+  `/opt/parishkit/credentials/google-service-account.json`.
+- Google OAuth user token files may default under
+  `/opt/parishkit/credentials/`.
+- Constant Contact client/token files may default under
+  `/opt/parishkit/credentials/`.
+- YAML configs may default under `/opt/parishkit/config/`.
+
+All such defaults must be overridable by CLI parameters and/or YAML config.
+
+## Configuration
+
+All parish-specific mappings and operational settings should be expressed as
+YAML files.
+
+Configuration examples to migrate from code into YAML:
+
+- Google calendar IDs and acceptable sender domains from
+  `calendar-reservations.py`.
+- Ministry-to-Google-Sheet mappings from `create-ministry-rosters.py`.
+- ParishSoft ministry/workgroup to Google Group mappings from
+  `sync-google-group.py`.
+- ParishSoft Member Workgroup to Constant Contact list mappings from
+  `cc_sync_config.py` and `sync-ps-to-cc.py`.
+
+Configuration must be validated at startup. Invalid config should fail fast
+with a clear error message before any external writes occur.
+
+Recommended implementation:
+
+- `parishkit.config` loads YAML.
+- Validation uses either dataclasses with explicit validation or a validation
+  library such as Pydantic.
+- Example configs are committed.
+- Real configs containing parish-specific private data are not committed.
+
+## Secrets and Credentials
+
+No secrets or credentials may be committed or hard-coded.
+
+This includes:
+
+- ParishSoft API keys.
+- Google Cloud service account JSON keys.
+- Google OAuth client secrets.
+- Google OAuth refresh/user token files.
+- Constant Contact OAuth tokens.
+- Slack bot tokens.
+- SMTP credentials.
+- Parish-specific private IDs if they should not be public.
+
+Secrets should be passed by command-line file paths, environment variables, or
+documented runtime deployment mechanisms.
+
+## ParishSoft
+
+Carry forward `python/ParishSoftv2.py` as the basis for
+`parishkit.parishsoft`. Do not carry forward `ParishSoftv1.py`.
+
+Goals:
+
+- Preserve useful v2 API behavior.
+- Keep local JSON caching with configurable cache age.
+- Keep useful cross-linking and helper/query functions.
+- Remove Epiphany/ECC-specific defaults.
+- Make expected organization names and validation settings configurable.
+- Ensure all REST calls use retry-aware sessions or decorators.
+- Keep API calls small enough that retrying a function is safe and atomic.
+
+The ParishSoft API key must be supplied at runtime, typically through
+`--ps-api-key-file`.
+
+Documentation should state that parishes must contact ParishSoft sales to
+purchase or obtain API access.
+
+## Constant Contact
+
+Carry forward `python/ConstantContact.py` as the basis for
+`parishkit.constant_contact`.
+
+Goals:
+
+- Preserve useful OAuth2 token handling, API pagination, list/contact helpers,
+  and ParishSoft linking behavior.
+- Keep retry behavior for transient API failures and rate limits.
+- Improve naming/style to match the new package.
+- Avoid assumptions about Epiphany-specific lists or notification addresses.
+- Ensure all mappings are supplied by YAML config.
+
+The Constant Contact module is shared library code and does not need to be
+executable.
+
+## Google APIs
+
+Modernize Google API usage.
+
+The existing code uses older `oauth2client` patterns in several places. The
+new repository should drop `oauth2client` and use current Google libraries:
+
+- `google-auth`
+- `google-auth-oauthlib`
+- `google-api-python-client`
+- `google-auth-httplib2` if needed by `google-api-python-client`
+
+Preferred auth strategy:
+
+1. Use Google Cloud service accounts with Google Workspace domain-wide
+   delegation wherever possible.
+2. Use user OAuth only for APIs or workflows where service-account delegation
+   cannot satisfy the requirement.
+
+Documentation should recommend one Google Cloud project per parish. This keeps
+IAM, API enablement, quotas, ownership, auditability, and offboarding scoped to
+the parish using the software.
+
+The top-level README should include setup guidance for:
+
+- Creating a Google Cloud project.
+- Enabling required APIs.
+- Creating service accounts.
+- Creating service account keys when needed.
+- Configuring domain-wide delegation in Google Workspace.
+- Creating OAuth clients for user-consent flows when needed.
+- Storing credential files outside git.
+- Passing credential file paths through CLI/config.
+
+## Email
+
+Create a modular email provider system under `parishkit.email`.
+
+Initial provider:
+
+- Google Workspace SMTP using XOAUTH2 and a service account with domain-wide
+  delegation.
+
+Future/stub provider:
+
+- Microsoft 365.
+
+The MS365 provider should include a clear interface and configuration shape,
+but it can be a stub in the first version because there is no available test
+environment.
+
+Email design goals:
+
+- Common send API used by all tools.
+- Provider selected at runtime from config/CLI.
+- No default sender address tied to Epiphany.
+- Support plain text and HTML bodies.
+- Support attachments where existing scripts need them.
+- Keep authentication setup separate from message construction.
+
+## Logging and Slack
+
+All tools should use shared logging setup from `parishkit.logging`.
+
+Required logging features:
+
+- Console logging.
+- Optional file logging.
+- Optional rotating logs.
+- Compression of rotated logs.
+- Common `--verbose` and `--debug` behavior.
+- Optional Slack handler for critical errors.
+
+Slack behavior:
+
+- Slack token is supplied at runtime.
+- Slack channel is configurable.
+- Slack emission is reserved for `CRITICAL` logs by default, matching the
+  behavior of the current codebase.
+- The Slack threshold may be configurable, but the default should remain
+  `CRITICAL`.
+- Failure to emit to Slack should be logged without masking the original
+  critical error.
+
+## Retry and REST API Calls
+
+All RESTful API usage may be modernized as part of the migration. Some of the
+existing scripts are old and may rely on stale client-library patterns, older
+REST endpoints, or outdated examples. It is acceptable, and often desirable, to
+move to current recommended APIs, client-library methods, request/response
+shapes, auth patterns, pagination behavior, and rate-limit handling.
+
+All RESTful API calls should also be wrapped in retry-aware helpers or
+decorators for common transient failures.
+
+This applies to:
+
+- Google APIs.
+- ParishSoft APIs.
+- Constant Contact APIs.
+- Slack APIs.
+- Future external APIs.
+
+Modernization examples:
+
+- Newer Google Drive, Calendar, Sheets, Groups, and Admin SDK client patterns.
+- Newer Constant Contact API endpoints or token-handling conventions.
+- Newer ParishSoft API conventions, if documented and compatible with the
+  needed data.
+- Newer Slack SDK/API conventions.
+- Replacing ad hoc `requests` usage with shared sessions and typed helper
+  functions where doing so improves correctness and maintainability.
+
+Modernization rules:
+
+- Preserve user-visible tool behavior unless an intentional behavior change is
+  requested or documented.
+- Prefer current official documentation and supported client libraries.
+- Keep compatibility risks visible in comments, tests, or migration notes.
+- Use mocked tests and manual smoke tests where real credentials are required
+  to verify modernized integrations.
+
+Retry rules:
+
+- Retry only atomic operations where repeating the call is safe.
+- Keep API-call functions small enough that retrying the whole function is
+  appropriate.
+- Respect service-specific rate-limit signals such as `Retry-After` when
+  available.
+- Do not retry validation errors, authentication errors, or permanent
+  authorization failures unless the API explicitly documents them as
+  transient.
+
+## Scripts to Migrate
+
+### Common Library Code
+
+From `python/`:
+
+- `ParishSoftv2.py` -> `parishkit.parishsoft`
+- `ConstantContact.py` -> `parishkit.constant_contact`
+- `Google.py` and `GoogleAuth.py` -> modules under `parishkit.google`
+- Useful parts of `ECC.py` -> `parishkit.logging`, `parishkit.email`, and
+  other neutral helpers as appropriate
+
+Do not carry forward:
+
+- `ParishSoftv1.py`
+- `ECC` naming
+- Epiphany-specific defaults in reusable modules
+- `ecc-python-modules` symlink/import pattern
+
+### ParishSoft Utilities
+
+From `ps-queries/utilities/`:
+
+- `print-member.py`
+- `print-ministries.py`
+
+`print-member.py` changes:
+
+- Accept a ParishSoft Member DUID, Family DUID, or name search from CLI.
+- Remove hard-coded DUIDs.
+- Add a CLI option controlling whether family contributions are loaded.
+- Use common ParishSoft/cache/logging options.
+
+`print-ministries.py` changes:
+
+- Use common ParishSoft/cache/logging options.
+- Use shared package imports.
+- Preserve the ability to print sorted ministry names.
+
+### Calendar Reservations
+
+From `media/linux/calendar-reservations/`:
+
+- `calendar-reservations.py`
+
+Changes:
+
+- Move calendar definitions and acceptable domains to YAML.
+- Use modern Google auth.
+- Use common logging, Slack, retry, and CLI behavior.
+- Preserve dry-run behavior.
+- Remove Epiphany-specific defaults from code.
+
+### ParishSoft to Google/Constant Contact Scripts
+
+From `media/linux/ps-queries/`:
+
+- `create-ministry-rosters.py`
+- `sync-google-group.py`
+- `sync-ps-to-cc.py`
+
+`create-ministry-rosters.py` changes:
+
+- Move ministry-to-sheet mappings to YAML.
+- Use modern Google auth.
+- Use shared ParishSoft, Google, logging, retry, and config helpers.
+
+`sync-google-group.py` changes:
+
+- Move synchronization mappings to YAML.
+- Use modern Google auth.
+- Keep notification behavior, but make all notification addresses configured.
+- Use shared email provider.
+- Use common dry-run/logging/retry behavior.
+
+`sync-ps-to-cc.py` changes:
+
+- Move `cc_sync_config.py` data to YAML.
+- Preserve the current cleaner action-list architecture.
+- Use shared ParishSoft, Constant Contact, email, logging, retry, and config
+  helpers.
+
+## Documentation
+
+Top-level `README.md` should include:
+
+- Project purpose.
+- Non-goals and neutrality statement.
+- Supported Python version.
+- Installation instructions.
+- Local development setup.
+- Local lint/style/test commands.
+- Overview of available tools.
+- Links to each script README.
+- ParishSoft API key instructions.
+- Google Cloud / Google Workspace authentication setup.
+- Secret handling rules.
+- Basic scheduled-job guidance.
+
+Each script README should include:
+
+- What the script does.
+- Required external systems.
+- Required credentials.
+- Required config file.
+- Example command.
+- Dry-run behavior.
+- Logging behavior.
+- Example YAML config.
+
+## Migration Support
+
+The implementation should create a `migrate-to-parishkit/` directory in this
+repository.
+
+That directory should contain:
+
+- `README.md` explaining how a human operator migrates scheduled jobs from the
+  old scripts to the new `parishkit` scripts.
+- New-style `config.yaml` files as appropriate for the migrated scripts,
+  including YAML conversions of existing hard-coded Python data structures.
+- `run.sh`-style cron wrapper scripts that call the new local `parishkit`
+  commands with equivalent config, credential, log, and cache paths.
+- Clear notes about which old script each wrapper replaces.
+- Any required manual setup steps, such as creating `/opt/parishkit`
+  directories, creating or copying credentials, installing the new package, and
+  updating cron entries.
+- Detailed credential setup instructions, not only copy instructions. The
+  migration README should describe how to create new credentials from scratch
+  as if the operator is setting up a new parish.
+
+The migration wrappers are transitional operational aids. They should not
+contain secrets and should not duplicate application logic.
+
+Migration config files may contain parish-specific operational identifiers
+converted from the old scripts, such as calendar IDs, Google Group mappings,
+ministry roster sheet IDs, and Constant Contact list mappings. They must not
+contain credentials or secrets.
+
+The migration README should include a fresh Google setup path:
+
+- Create a new Google Cloud project for the parish.
+- Enable the required Google APIs.
+- Create service accounts where domain-wide delegation is appropriate.
+- Enable domain-wide delegation on the service account.
+- Configure the service account client ID and required scopes in Google
+  Workspace Admin.
+- Create and securely store service account JSON keys if key-based auth is
+  used.
+- Create OAuth consent configuration and OAuth client credentials for any
+  workflows that still require user OAuth.
+- Generate any required user OAuth token files.
+- Place credentials under `/opt/parishkit/credentials/` or pass alternate
+  paths through CLI/config.
+- Update YAML config and cron wrappers to reference the chosen credential
+  paths.
+
+The README may also include an optional shortcut for reusing existing
+credentials during migration, but the complete new-project setup should be
+documented first.
+
+## Agent Instructions
+
+The new repository should have:
+
+- `CLAUDE.md`
+- `AGENTS.md` as a symlink to `CLAUDE.md`
+
+The instructions should include:
+
+- Purpose of the project.
+- Guidance for ongoing development and maintenance of the `parishkit`
+  repository, not migration-only instructions.
+- Rule that reusable code must remain parish-neutral.
+- Python 3.12+ requirement.
+- Executable wrappers must have a shebang and executable bit.
+- No ad hoc `sys.path` changes.
+- No committed secrets or credentials.
+- Keep `.gitignore` updated for generated files, local credentials, logs,
+  caches, virtual environments, and other local operational artifacts.
+- Config must be YAML for parish-specific mappings.
+- Use shared logging/CLI/retry/auth helpers.
+- Use `ruff` and `pytest`.
+- Local validation commands.
+- Preserve existing tool behavior unless an intentional behavior change is
+  requested or documented.
+- All commits should include a Developer Certificate of Origin
+  `Signed-off-by:` trailer.
+- There is no requirement for LLM attribution in commits.
+- Use the Common Convention commit style.
+- Prefer self-contained commits that leave the repository in a consistent
+  state, so tools such as `git bisect` remain useful.
+- Put drive-by fixes in their own commits instead of combining them with
+  larger behavior changes.
+- Squash fixup commits appropriately before pull requests are merged into their
+  target branches.
+- Prefer thorough commit messages that explain why the change exists, not only
+  what changed.
+- Commit message body lines should wrap at approximately 75 characters.
+- GitHub pull request and issue descriptions should use GitHub's normal
+  convention of one line per paragraph and let GitHub render wrapping.
+
+## Dependencies
+
+Create a top-level `requirements.txt` with grouped comments.
+
+Expected dependency groups:
+
+- Runtime core.
+- Google APIs/auth.
+- HTTP/retry.
+- YAML/config validation.
+- Email/Slack.
+- Testing.
+- Linting/formatting.
+
+The exact package list will be finalized during implementation, but should
+include at least:
+
+- `google-api-python-client`
+- `google-auth`
+- `google-auth-oauthlib`
+- `google-auth-httplib2`
+- `requests`
+- `urllib3`
+- `PyYAML`
+- `slack_sdk`
+- `pytest`
+- `ruff`
+
+Avoid carrying forward obsolete dependencies unless a specific migrated script
+still requires them. In particular, do not use `oauth2client`.
+
+## CI and Local Validation
+
+Use GitHub Actions for:
+
+- Python linting.
+- Python style/format checks.
+- Python unit tests.
+- Developer Certificate of Origin checks for `Signed-off-by:` trailers.
+
+Use the same commands locally and in CI.
+
+Recommended commands:
+
+```bash
+python -m pip install -r requirements.txt
+ruff check .
+ruff format --check .
+pytest
+```
+
+The top-level README and `CLAUDE.md`/`AGENTS.md` should document these
+commands.
+
+The DCO workflow should use a maintained GitHub Action suitable for checking
+commit sign-off trailers in pull requests. The exact action/version should be
+selected during implementation based on current maintenance status.
+
+## External-Service Validation
+
+Automated unit tests should not require real ParishSoft, Google, Constant
+Contact, Slack, or email-provider credentials. Those tests should use mocks,
+fixtures, and local sample data wherever practical.
+
+Some success conditions still require confidence that real credentials and
+external integrations work. For those cases, implementation may include
+throwaway or one-time smoke-test tools that a human operator runs manually with
+real credentials. These tools should:
+
+- Be clearly documented as manual validation tools.
+- Require credentials through CLI options or environment-variable references.
+- Avoid committing credentials, tokens, API responses with private data, or
+  generated artifacts.
+- Prefer read-only API checks where possible.
+- Use explicit `--dry-run` or confirmation requirements before any external
+  write.
+- Keep output minimal and redact sensitive values.
+- Be excluded from normal CI.
+
+Examples include a Google auth smoke test, a Google Workspace email smoke test,
+a ParishSoft API connectivity smoke test, a Constant Contact token/list smoke
+test, and a Slack notification smoke test.
+
+## Migration Quality Bar
+
+Before considering the migration complete:
+
+- All wrappers have shebangs and executable bits.
+- No reusable module names contain `ECC`.
+- No reusable code has Epiphany-specific defaults.
+- No code relies on `ecc-python-modules` symlinks.
+- No code uses `oauth2client`.
+- All hard-coded operational mappings have moved to YAML.
+- All scripts use common CLI/logging/config conventions.
+- All scripts can run in dry-run mode where external writes are possible.
+- Critical errors can be sent to Slack when configured.
+- REST calls have appropriate retry behavior.
+- Unit tests cover shared logic and action computation.
+- Manual external-service smoke tests exist or are documented where real
+  credentials are required to validate behavior beyond mocks.
+- DCO sign-off checking is enabled in GitHub Actions.
+- CI passes.
+- `migrate-to-parishkit/` contains migration wrappers and operator
+  documentation.
+
+Perform a final source search for terms such as:
+
+```text
+ECC
+Epiphany
+churchofepiphany
+epiphanycatholicchurch
+Louisville
+ecc-python-modules
+oauth2client
+```
+
+Any remaining occurrences must be either removed, generalized, or explicitly
+documented as historical/example-only text.

--- a/specs/evolve-to-parishkit/tasks.md
+++ b/specs/evolve-to-parishkit/tasks.md
@@ -1,0 +1,560 @@
+# Evolve to `parishkit` Implementation Tasks
+
+## Per-Phase Review Loop
+
+At the end of each implementation phase, before the phase success condition is
+accepted and before moving to the next phase, run an iterative code review and
+fix loop.
+
+- [ ] Launch three independent code-specialist review agents with minimal
+      context for the completed phase:
+      - One focused on code correctness and behavioral regressions.
+      - One focused on software quality, maintainability, testing, and
+        operational robustness.
+      - One focused on overall software design, module boundaries, extensibility,
+        and fit with the `parishkit` architecture.
+- [ ] Give each review agent only the phase objective, relevant changed files,
+      tests, and local conventions needed for that review.
+- [ ] Require each review agent to report findings with severity, file/line
+      references, concrete impact, and a recommended fix.
+- [ ] Have the coordinator collate and de-duplicate all review findings.
+- [ ] Have the coordinator validate each finding against the code and push back
+      on findings that are incorrect, speculative, out of scope, or lower value
+      than their stated severity.
+- [ ] Fix every validated finding with `MEDIUM` severity or higher before the
+      phase is considered complete.
+- [ ] Re-run the relevant local validation commands after fixes.
+- [ ] Repeat the multi-agent review round after fixes.
+- [ ] Exit the review and fix loop only when the coordinator fixes nothing in a
+      review round.
+
+This loop applies to every implementation phase below, including focused script
+migration phases and the final cleanup/validation phase.
+
+## 1. Create the New Repository
+
+- [x] Choose the local path for the new `parishkit` repository.
+- [x] Initialize a new git repository named `parishkit`.
+- [x] Add a reasonable `.gitignore` for Python, virtualenvs, caches, logs,
+      credentials, generated reports, local config, and `/opt/parishkit`-style
+      runtime artifacts copied into a checkout.
+- [x] Create the standard repository layout:
+      - `src/parishkit/`
+      - `src/parishkit/google/`
+      - `src/parishkit/email/`
+      - `scripts/`
+      - `tests/`
+      - `.github/workflows/`
+- [x] Add `README.md`, `CLAUDE.md`, and `AGENTS.md` symlinked to
+      `CLAUDE.md`.
+- [x] Add `pyproject.toml`.
+- [x] Add grouped top-level `requirements.txt`.
+
+Success condition: a fresh `parishkit` git checkout exists locally with the
+expected top-level files and directories, no credentials or generated runtime
+files committed, and `AGENTS.md` resolving to `CLAUDE.md`.
+
+## 2. Development Tooling and CI
+
+- [x] Configure Python 3.12+ project metadata in `pyproject.toml`.
+- [x] Configure `ruff` linting.
+- [x] Configure `ruff format`.
+- [x] Configure `pytest`.
+- [x] Add console entry points for all planned tools:
+      - `parishkit-run`
+      - `parishkit-print-member`
+      - `parishkit-print-ministries`
+      - `parishkit-calendar-reservations`
+      - `parishkit-create-ministry-rosters`
+      - `parishkit-sync-google-group`
+      - `parishkit-sync-ps-to-cc`
+- [x] Add GitHub Actions workflow for `ruff check`.
+- [x] Add GitHub Actions workflow step for `ruff format --check`.
+- [x] Add GitHub Actions workflow step for `pytest`.
+- [x] Add GitHub Actions DCO check for `Signed-off-by:` trailers, using a
+      maintained action selected during implementation.
+- [x] Document local validation commands in `README.md` and `CLAUDE.md`.
+- [x] Document that normal CI must not require real external-service
+      credentials.
+- [x] Document the pattern for manual, human-run external-service smoke tests
+      when real credentials are needed.
+
+Success condition: a developer can install dependencies, run the documented
+local validation commands, and see the same lint, format, test, and DCO checks
+represented in GitHub Actions. CI does not require real ParishSoft, Google,
+Constant Contact, Slack, or email-provider credentials.
+
+## 3. Repository Documentation
+
+- [x] Write top-level `README.md` with project purpose and neutrality goals.
+- [x] Document Python 3.12+ requirement.
+- [x] Document installation and local development setup.
+- [x] Document local lint/style/test commands.
+- [x] Document available tools and link to script READMEs.
+- [x] Document default runtime paths under `/opt/parishkit`.
+- [x] Document secret handling rules.
+- [x] Document manual external-service smoke-test conventions:
+      - credentials supplied at runtime,
+      - read-only checks preferred,
+      - dry-run or explicit confirmation for writes,
+      - sensitive values redacted from output,
+      - smoke tests excluded from normal CI.
+- [x] Document ParishSoft API key requirements and sales/API-access note.
+- [x] Document fresh Google Cloud / Google Workspace setup:
+      - New Google Cloud project per parish.
+      - Required APIs.
+      - Service accounts.
+      - Domain-wide delegation.
+      - Workspace Admin scopes.
+      - Service account JSON keys.
+      - OAuth consent/client setup for workflows that need user OAuth.
+      - Credential placement under `/opt/parishkit/credentials/`.
+- [x] Write `CLAUDE.md` with general agent/developer conventions for ongoing
+      `parishkit` development:
+      - Parish-neutral reusable code.
+      - Python 3.12+.
+      - Executable wrappers require shebangs and executable bits.
+      - No ad hoc `sys.path`.
+      - No committed secrets.
+      - Keep `.gitignore` updated for generated files, credentials, logs,
+        caches, virtual environments, and local operational artifacts.
+      - YAML config for parish-specific mappings.
+      - Shared logging/CLI/retry/auth helpers.
+      - `ruff` and `pytest`.
+      - Preserve existing tool behavior unless an intentional behavior change
+        is requested or documented.
+      - DCO `Signed-off-by:` trailers.
+      - No LLM attribution requirement.
+      - Common Convention commit style.
+      - Prefer self-contained commits that leave the repository in a consistent
+        state for tools such as `git bisect`.
+      - Put drive-by fixes in their own commits.
+      - Squash fixup commits before pull requests are merged into their target
+        branches.
+      - Thorough commit messages explaining why.
+      - Commit body wrapping at approximately 75 characters.
+      - GitHub issue/PR descriptions use one line per paragraph.
+
+Success condition: a new parish operator and a new developer can read the
+top-level docs and understand how to install the project, configure credentials,
+run tools, validate changes, and follow repository conventions without relying
+on information from the old repository.
+
+## 4. Shared CLI, Config, Logging, and Retry Foundations
+
+- [x] Implement `parishkit.cli` helpers for common arguments:
+      - `--config`
+      - `--dry-run`
+      - `--verbose`
+      - `--debug`
+      - `--log-file`
+      - `--log-dir`
+      - `--slack-token-file`
+      - `--slack-channel`
+      - `--slack-log-level`
+      - `--ps-api-key-file`
+      - `--ps-cache-dir`
+      - `--ps-cache-limit`
+- [x] Implement default path constants rooted under `/opt/parishkit`.
+- [x] Implement `parishkit.config` YAML loading.
+- [x] Implement config validation strategy.
+- [x] Implement clear startup errors for invalid config.
+- [x] Implement `parishkit.logging`:
+      - Console logging.
+      - Optional file logging.
+      - Rotating logs.
+      - Compression for rotated logs.
+      - Slack handler.
+      - Default Slack threshold of `CRITICAL`.
+      - Configurable Slack threshold.
+- [x] Implement `parishkit.retry` helpers for retry-safe REST/API calls.
+- [x] Document that REST API usage may be modernized during migration when
+      current supported APIs or client-library patterns are better than the old
+      script patterns.
+- [x] Add unit tests for CLI defaults, config loading, logging setup, and retry
+      behavior.
+- [x] Add a documented manual Slack notification smoke-test tool for a human
+      operator to run with a real Slack token.
+
+Success condition: shared CLI/config/logging/retry modules are importable,
+covered by focused tests, and usable by a small sample command without each
+tool reimplementing common option parsing, logging, YAML loading, or retry
+behavior. Real Slack notification validation is available through a documented
+human-run smoke test.
+
+## 5. Scheduled Job Runner
+
+- [x] Create `parishkit.runner`.
+- [x] Add `parishkit-run` console entry point.
+- [x] Create `scripts/run/`.
+- [x] Add `scripts/run/parishkit-run.py` executable wrapper.
+- [x] Ensure the wrapper starts with `#!/usr/bin/env python3`.
+- [x] Ensure the wrapper has its executable bit set.
+- [x] Add `scripts/run/README.md`.
+- [x] Add `scripts/run/example-config.yaml`.
+- [x] Implement lockfile support to prevent concurrent runs.
+- [x] Implement stale-lock detection.
+- [x] Implement configurable stale-lock behavior:
+      - exit and alert,
+      - remove stale lock and continue,
+      - fail closed.
+- [x] Write useful lock metadata, such as host, PID, command, start time, and
+      configured timeout.
+- [x] Clean up locks on normal exit and handled exceptions.
+- [x] Handle termination signals where practical.
+- [x] Implement top-level runner logging through `parishkit.logging`.
+- [x] Implement top-level Slack reporting through the shared Slack handler.
+- [x] Implement watchdog timeout support for child jobs.
+- [x] Capture child stdout/stderr for logs and optional Slack reporting.
+- [x] Add optional Slack notification on successful runs.
+- [x] Add optional contextual Slack comments.
+- [x] Define clear cron-friendly exit codes.
+- [x] Load runner job lists from YAML.
+- [x] Use `/opt/parishkit/config/runner.yaml` or an equivalent documented path
+      as the default runner config when `--config` is not supplied.
+- [x] Run all configured/enabled jobs when no explicit job selection is
+      supplied.
+- [x] Support CLI selection of one or more configured jobs to run.
+- [x] Support config-file enabled/disabled selection for jobs.
+- [x] Support documented override behavior for explicitly running disabled
+      jobs, if that behavior is implemented.
+- [x] Support simple no-config mode that runs a CLI-supplied command under the
+      same lockfile, logging, Slack, and watchdog protections.
+- [x] Exit with a clear configuration error when no runner config is available
+      and no CLI command is supplied.
+- [x] Support per-job working directory.
+- [x] Support per-job environment overrides.
+- [x] Support per-job timeout.
+- [x] Support per-job enabled/disabled flag.
+- [x] Support stop-on-first-failure and continue-and-summarize modes.
+- [x] Prefer argument-list commands without shell interpolation by default.
+- [x] Add an explicit shell mode only if needed and clearly documented.
+- [x] Add unit tests for lock acquisition, active-lock exit, stale-lock
+      handling, timeout behavior, and exit-code behavior.
+- [x] Add mocked tests for Slack failure/success reporting.
+
+Success condition: `parishkit-run` can run a YAML-defined job list, run a
+selected subset of jobs, run a single CLI-supplied command without config,
+prevent concurrent execution with a lockfile, enforce timeouts, report failures
+through logging/Slack, and pass its runner tests.
+
+## 6. Google API Modernization
+
+- [x] Create `parishkit.google.auth`.
+- [x] Replace `oauth2client` patterns with `google-auth` and
+      `google-auth-oauthlib`.
+- [x] Implement service-account credential loading.
+- [x] Implement service-account domain-wide delegation helper.
+- [x] Implement user OAuth helper for workflows that cannot use service
+      accounts.
+- [x] Implement Google API service builder helper.
+- [x] Implement common Google retry/error handling.
+- [x] Review current Google Drive, Calendar, Sheets, Groups, and Admin SDK
+      usage and modernize stale API/client-library patterns where appropriate.
+- [x] Create initial Google modules as needed:
+      - `calendar.py`
+      - `drive.py`
+      - `groups.py`
+      - `sheets.py`
+- [x] Add unit tests with mocked Google clients.
+- [x] Add a documented manual Google auth/API smoke-test tool if mocked tests
+      cannot prove real credential setup works.
+- [x] Verify no migrated code imports or depends on `oauth2client`.
+
+Success condition: Google auth/service helpers support service-account DWD and
+user OAuth where needed, all tests use mocked Google clients, and a repository
+search confirms no migrated code depends on `oauth2client`. Any real-credential
+validation needed beyond mocks is available as a documented human-run smoke
+test.
+
+## 7. Email Provider System
+
+- [x] Create `parishkit.email.base` provider interface.
+- [x] Implement Google Workspace SMTP/XOAUTH2 provider.
+- [x] Support service-account domain-wide delegation for Gmail SMTP.
+- [x] Support plain text email.
+- [x] Support HTML email.
+- [x] Support attachments needed by migrated scripts.
+- [x] Add MS365 provider stub with documented config shape.
+- [x] Add tests for provider selection and message construction.
+- [x] Add tests for Google Workspace auth/message flow using mocks.
+- [x] Add a documented manual Google Workspace email smoke-test tool for a
+      human operator to run with real credentials.
+
+Success condition: tools can select an email provider through shared config,
+Google Workspace SMTP/XOAUTH2 message construction is tested with mocks, and
+the MS365 placeholder fails clearly with documented configuration expectations.
+Real email-provider validation is available through documented human-run smoke
+tests where credentials are required.
+
+## 8. ParishSoft Library
+
+- [x] Port useful functionality from `python/ParishSoftv2.py` to
+      `parishkit.parishsoft`.
+- [x] Do not port `ParishSoftv1.py`.
+- [x] Remove Epiphany/ECC-specific defaults.
+- [x] Make expected organization validation configurable.
+- [x] Review current ParishSoft API usage and modernize stale request,
+      pagination, or response-handling patterns where appropriate and
+      compatible.
+- [x] Preserve JSON caching with configurable cache age.
+- [x] Preserve useful data cross-linking behavior.
+- [x] Preserve useful family/member/workgroup/ministry helper functions.
+- [x] Ensure all ParishSoft REST calls use retry-aware sessions/helpers.
+- [x] Keep retry scopes atomic and safe.
+- [x] Add unit tests for cache-limit parsing.
+- [x] Add unit tests for family/member helper functions.
+- [x] Add unit tests for salutation logic.
+- [x] Add mocked tests for API paging and retry behavior.
+- [x] Add a documented manual ParishSoft connectivity smoke-test tool for a
+      human operator to run with a real API key.
+
+Success condition: `parishkit.parishsoft` exposes the migrated v2 data-loading
+and helper behavior without Epiphany-specific defaults, uses retry-aware API
+access, and has tests for cache parsing, helpers, salutations, paging, and
+retry behavior. Real ParishSoft credential validation is available through a
+documented human-run smoke test.
+
+## 9. Constant Contact Library
+
+- [x] Port useful functionality from `python/ConstantContact.py` to
+      `parishkit.constant_contact`.
+- [x] Preserve OAuth token load/save/refresh behavior.
+- [x] Preserve paginated API helpers.
+- [x] Preserve contact/list linking helpers.
+- [x] Preserve ParishSoft contact linking behavior.
+- [x] Preserve `CCAPIError` or equivalent typed API exception.
+- [x] Review current Constant Contact API usage and modernize stale endpoint,
+      token, pagination, or rate-limit patterns where appropriate.
+- [x] Ensure all Constant Contact REST calls use retry-aware sessions/helpers.
+- [x] Remove Epiphany/ECC-specific defaults.
+- [x] Add unit tests for token serialization.
+- [x] Add unit tests for API pagination using mocks.
+- [x] Add unit tests for contact/list linking.
+- [x] Add unit tests for action-support helpers used by sync scripts.
+- [x] Add a documented manual Constant Contact token/list smoke-test tool for a
+      human operator to run with real credentials.
+
+Success condition: `parishkit.constant_contact` can authenticate, paginate,
+link contacts/lists/ParishSoft members, and raise typed API errors through
+tested code paths without parish-specific mappings embedded in the module. Real
+Constant Contact credential validation is available through a documented
+human-run smoke test.
+
+## 10. Script Wrapper Skeletons
+
+- [x] Create `scripts/run/`.
+- [x] Create `scripts/print-member/`.
+- [x] Create `scripts/print-ministries/`.
+- [x] Create `scripts/calendar-reservations/`.
+- [x] Create `scripts/create-ministry-rosters/`.
+- [x] Create `scripts/sync-google-group/`.
+- [x] Create `scripts/sync-ps-to-cc/`.
+- [x] Add executable wrapper script in each directory.
+- [x] Ensure each wrapper starts with `#!/usr/bin/env python3`.
+- [x] Ensure each wrapper has its executable bit set.
+- [x] Add `README.md` in each script directory.
+- [x] Add `example-config.yaml` in each script directory.
+
+Success condition: every planned command has both a console entry point and an
+executable wrapper with a shebang, README, and example config, and each wrapper
+delegates to package code instead of containing application logic.
+
+## 11. Migrate `print-member`
+
+- [x] Port `ps-queries/utilities/print-member.py`.
+- [x] Remove hard-coded DUIDs.
+- [x] Add CLI support for ParishSoft Member DUID lookup.
+- [x] Add CLI support for ParishSoft Family DUID lookup.
+- [x] Add CLI support for name search.
+- [x] Add option controlling whether contributions are loaded.
+- [x] Use shared ParishSoft/cache/logging/CLI helpers.
+- [x] Add dry-run behavior if any external writes are introduced.
+- [x] Add tests for argument parsing and lookup selection.
+- [x] Update script README and example config.
+
+Success condition: `parishkit-print-member` can look up members/families by
+the supported CLI selectors without hard-coded DUIDs, optionally load
+contributions, use shared ParishSoft/logging options, and pass its tests.
+
+## 12. Migrate `print-ministries`
+
+- [x] Port `ps-queries/utilities/print-ministries.py`.
+- [x] Use shared ParishSoft/cache/logging/CLI helpers.
+- [x] Preserve sorted ministry-name output.
+- [x] Add tests for ministry extraction/sorting.
+- [x] Update script README and example config.
+
+Success condition: `parishkit-print-ministries` produces the expected sorted
+ministry list using shared ParishSoft/logging options and passes tests for the
+ministry extraction and sorting behavior.
+
+## 13. Migrate `calendar-reservations`
+
+- [x] Port `media/linux/calendar-reservations/calendar-reservations.py`.
+- [x] Move calendar definitions to YAML.
+- [x] Move acceptable domains to YAML.
+- [x] Use modern Google auth.
+- [x] Modernize Google Calendar API usage where current supported patterns are
+      better than the old script implementation.
+- [x] Use shared Google Calendar helpers.
+- [x] Use shared logging, Slack, retry, CLI, and config helpers.
+- [x] Preserve dry-run behavior.
+- [x] Remove Epiphany-specific defaults from code.
+- [x] Add tests for config validation.
+- [x] Add tests for conflict-detection logic.
+- [x] Add mocked tests for Google Calendar API calls.
+- [x] Update script README and example config.
+
+Success condition: `parishkit-calendar-reservations` uses YAML calendars and
+domains, modern Google auth, shared logging/Slack/retry behavior, preserves
+dry-run behavior, has no Epiphany-specific defaults in code, and passes config,
+conflict, and mocked Calendar API tests.
+
+## 14. Migrate `create-ministry-rosters`
+
+- [x] Port `media/linux/ps-queries/create-ministry-rosters.py`.
+- [x] Move ministry-to-sheet mappings to YAML.
+- [x] Preserve role-sheet behavior.
+- [x] Use modern Google auth.
+- [x] Modernize Google Sheets/Drive API usage where current supported patterns
+      are better than the old script implementation.
+- [x] Use shared Google Sheets/Drive helpers.
+- [x] Use shared ParishSoft/cache/logging/retry/CLI/config helpers.
+- [x] Remove Epiphany-specific defaults from code.
+- [x] Add tests for roster config validation.
+- [x] Add tests for roster generation logic where practical.
+- [x] Add mocked tests for Google Sheets/Drive writes.
+- [x] Update script README and example config.
+
+Success condition: `parishkit-create-ministry-rosters` reads ministry roster
+mappings from YAML, writes rosters through shared Google helpers, preserves
+role-sheet behavior, removes parish-specific code defaults, and passes config,
+roster-generation, and mocked Google write tests.
+
+## 15. Migrate `sync-google-group`
+
+- [x] Port `media/linux/ps-queries/sync-google-group.py`.
+- [x] Move synchronization mappings to YAML.
+- [x] Preserve ministry/workgroup source behavior.
+- [x] Preserve Google Group role handling.
+- [x] Preserve notification behavior with all addresses configured.
+- [x] Use modern Google auth.
+- [x] Modernize Google Groups/Admin SDK API usage where current supported
+      patterns are better than the old script implementation.
+- [x] Use shared Google Groups helper.
+- [x] Use shared email provider.
+- [x] Use shared ParishSoft/cache/logging/retry/CLI/config helpers.
+- [x] Preserve dry-run behavior.
+- [x] Remove Epiphany-specific defaults from code.
+- [x] Add tests for config validation.
+- [x] Add tests for desired-state computation.
+- [x] Add tests for add/remove/change-role action computation.
+- [x] Add mocked tests for Google Group API calls.
+- [x] Update script README and example config.
+
+Success condition: `parishkit-sync-google-group` reads all sync mappings and
+notifications from YAML, computes add/remove/role-change actions correctly,
+preserves dry-run behavior, uses shared Google/email/ParishSoft/logging
+helpers, and passes mocked Google Groups tests.
+
+## 16. Migrate `sync-ps-to-cc`
+
+- [x] Port `media/linux/ps-queries/sync-ps-to-cc.py`.
+- [x] Move `cc_sync_config.py` data to YAML.
+- [x] Preserve current action-list architecture.
+- [x] Preserve unsubscribed-contact filtering.
+- [x] Preserve optional name-update behavior.
+- [x] Preserve no-sync and dry-run behavior.
+- [x] Use shared ParishSoft/cache/logging/retry/CLI/config helpers.
+- [x] Use shared Constant Contact library.
+- [x] Modernize Constant Contact API usage through the shared library where
+      current supported patterns are better than the old script implementation.
+- [x] Use shared email provider.
+- [x] Remove Epiphany-specific defaults from code.
+- [x] Add tests for config validation.
+- [x] Add tests for desired-state resolution.
+- [x] Add tests for unsubscribed filtering.
+- [x] Add tests for create/subscribe/unsubscribe/name-update action
+      computation.
+- [x] Add mocked tests for Constant Contact writes.
+- [x] Update script README and example config.
+
+Success condition: `parishkit-sync-ps-to-cc` reads Constant Contact mappings
+from YAML, preserves the action-list architecture and no-sync/dry-run behavior,
+correctly handles unsubscribed contacts and optional name updates, and passes
+action-computation plus mocked Constant Contact write tests.
+
+## 17. Build Migration Support in the Old Repository
+
+- [x] Create `migrate-to-parishkit/` in this repository.
+- [x] Add `migrate-to-parishkit/README.md`.
+- [x] Document how to install the new local `parishkit` package.
+- [x] Document how to create `/opt/parishkit` directories.
+- [x] Document how to create fresh ParishSoft, Google, Constant Contact, and
+      Slack credentials as needed.
+- [x] Include full fresh Google setup instructions:
+      - Create a new Google Cloud project.
+      - Enable required APIs.
+      - Create service accounts.
+      - Enable domain-wide delegation.
+      - Configure Workspace Admin client ID/scopes.
+      - Create and store service account JSON keys if used.
+      - Configure OAuth consent and OAuth clients where needed.
+      - Generate user OAuth token files where needed.
+      - Store credentials under `/opt/parishkit/credentials/` or configure
+        alternate paths.
+- [x] Document optional reuse/copying of existing credentials as a migration
+      shortcut.
+- [x] Convert hard-coded operational data to new-style YAML configs:
+      - Calendar reservation calendars/domains.
+      - Ministry roster sheet mappings.
+      - Google Group sync mappings.
+      - Constant Contact sync mappings.
+- [x] Store converted migration configs under `migrate-to-parishkit/`.
+- [x] Ensure migration configs contain no credentials or secrets.
+- [x] Add cron-friendly `run.sh`-style wrappers for migrated jobs.
+- [x] Ensure wrappers call the new `parishkit` commands.
+- [x] Ensure wrappers use `/opt/parishkit` defaults where appropriate.
+- [x] Document which old script each wrapper replaces.
+- [x] Document cron changes required by the human operator.
+
+Success condition: the old repository contains `migrate-to-parishkit/` with
+operator documentation, converted non-secret YAML configs, and cron-friendly
+wrappers that call the new `parishkit` commands with equivalent operational
+behavior and clear manual migration steps.
+
+## 18. Final Cleanup and Validation
+
+- [x] Run `ruff check .` in the new repository.
+- [x] Run `ruff format --check .` in the new repository.
+- [x] Run `pytest` in the new repository.
+- [x] Verify all script wrappers have executable bits.
+- [x] Verify all script wrappers have `#!/usr/bin/env python3`.
+- [x] Verify no migrated code uses `oauth2client`.
+- [x] Verify no migrated code uses the `ecc-python-modules` symlink pattern.
+- [x] Verify intentionally modernized REST API usage is documented in code,
+      tests, README notes, or migration notes where compatibility risk exists.
+- [x] Search for old naming and parish-specific defaults:
+      - `ECC`
+      - `Epiphany`
+      - `churchofepiphany`
+      - `epiphanycatholicchurch`
+      - `Louisville`
+      - `ecc-python-modules`
+      - `oauth2client`
+- [x] Remove, generalize, or explicitly document any remaining occurrences.
+- [x] Verify no credentials or secrets are committed.
+- [x] Verify CI passes.
+- [x] Verify DCO action is configured.
+- [x] Verify manual external-service smoke-test tools are documented for any
+      integration that cannot be fully validated with mocks.
+- [x] Verify migration README and wrappers are present in the old repository.
+- [x] Make final signed-off commit(s) using the required commit style.
+
+Success condition: all local validation commands pass, CI/DCO are configured,
+the final source searches have no unexplained legacy/parish-specific matches,
+no secrets are committed, migration support is present, and the finished work is
+captured in signed-off commits with wrapped, explanatory messages. Any
+remaining real-credential validation path is documented as a human-run smoke
+test and is not required by normal CI.


### PR DESCRIPTION
Add the spec, task list, operator notes, wrappers, and starter configs for migrating Epiphany's parish automation off the per-script setup in this repository and onto the new standalone `parishkit` package (https://github.com/epiphany40223/parishkit).

The goal is to extract the reusable Python glue (ParishSoft, Constant Contact, Google Workspace, Slack) into an installable package with ECC-specific assumptions -- names, domains, Google object IDs, ministry and Constant Contact list mappings, credentials -- supplied at runtime via CLI options and YAML config instead of being baked into the code.

specs/evolve-to-parishkit/:

- spec.md describes the target `parishkit` repository: the src layout, the `parishkit-*` CLI naming, common CLI conventions, the scheduled job runner, runtime paths, config and credential handling, the ParishSoft / Constant Contact / Google / email / Slack / retry modules, the set of scripts to migrate, and the migration quality bar.
- tasks.md breaks that work into 18 phases, from creating the repo and CI through the shared foundations and the per-script migrations (print-member, print-ministries, calendar-reservations, create-ministry-rosters, sync-google-group, sync-ps-to-cc) to building the migration support that lives here and final validation.

migrate-to-parishkit/:

- README.md is the operator runbook: installing the package, creating /opt/parishkit runtime directories, provisioning fresh ParishSoft, Google, Constant Contact, and Slack credentials, and swapping the old cron entries for the new wrappers and the shared pk-cron-runner.
- wrappers/ holds thin cron-friendly shell wrappers that call the new `pk-*` commands against their matching config files.
- configs/ holds non-secret starter YAML for each migrated job (validate-gcalendar-reservations, create-ps-ministry-rosters, sync-ps-to-ggroup, sync-ps-to-cc) plus the cron-runner config. These contain generic sample data only and must be edited for site-specific IDs and addresses before cron is enabled.

These files document and stage the migration; they do not change any of the existing scripts in this repository.