### PR TITLE
slack/runner: fix Slack error reporting crashes

### DIFF
--- a/slack/runner.py
+++ b/slack/runner.py
@@ -152,14 +152,18 @@ def runner(args, log):
         token = fp.read().strip()
     slack_client = slack_sdk.WebClient(token=token)
     response = slack_client.chat_postMessage(channel=args.slack_channel,
-                                            blocks=blocks)
+                                            blocks=blocks,
+                                            text=f"runner.py {type} notification")
     log.info(f"Sent {type} notification message blocks to Slack")
     log.debug(blocks)
 
     # Sadly, blocks can't include files.  So upload those separately (and
     # remove the corresponding local temporary files).
+    # files_upload_v2() requires a channel ID (not a channel name); get
+    # the ID from the response of the chat_postMessage call, above.
+    channel_id = response['channel']
     for file in files:
-        response = slack_client.files_upload(channels=args.slack_channel,
+        response = slack_client.files_upload_v2(channel=channel_id,
                                             title=file['title'],
                                             file=file['filename'])
         os.unlink(file['filename'])

--- a/slack/runner.py
+++ b/slack/runner.py
@@ -61,7 +61,10 @@ def runner(args, log):
     # Creates a temporary text file and writes content to it.
     # The file must manually be removed later!
     def _add_file(files, type, content_blob):
-        content  = content_blob.decode("utf-8").strip()
+        if isinstance(content_blob, str):
+            content = content_blob.strip()
+        else:
+            content = content_blob.decode("utf-8").strip()
         fp       = tempfile.NamedTemporaryFile(mode="w", delete=False)
         filename = fp.name
         fp.write(content)


### PR DESCRIPTION
Fix two crashes in `slack/runner.py` that were preventing failure notifications from reaching Slack.

First, `_add_file()` called `.decode("utf-8")` on `result.stdout`/`result.stderr`, but the child process is run with `text=True`, so those are already `str`. This raised an `AttributeError` exactly when a child process failed with non-empty output — i.e., precisely when the error notification was supposed to be sent. `_add_file()` now handles both `str` and bytes content.

Second, Slack has retired the old `files.upload` API (it now returns `method_deprecated`), so uploading the child's stdout/stderr crashed. Switched to `files_upload_v2()`, which requires a channel ID instead of a channel name; the ID is taken from the `chat_postMessage()` response we already receive. Also added the recommended top-level `text` fallback argument to `chat_postMessage()`, which silences a slack_sdk `UserWarning` and gives push notifications / screen readers something to render.

The str/bytes fix has been exercised on the production media machine (the failure notification message now reaches Slack); the `files_upload_v2()` upload path has not yet been exercised against a real failing job.
