### PR TITLE
sync-to-ggroup: rename WordPress backups group

### DIFF
--- a/migrate-to-parishkit/configs/pk-sync-ps-to-ggroup.yaml
+++ b/migrate-to-parishkit/configs/pk-sync-ps-to-ggroup.yaml
@@ -761,7 +761,7 @@ sync:
         - "ps-google-sync@epiphanycatholicchurch.org"
       workgroups:
         - "Worship Administration"
-    - group: "wordpress-backups@epiphanycatholicchurch.org"
+    - group: "wordpress-backups-access@epiphanycatholicchurch.org"
       notify:
         - "ps-google-sync@epiphanycatholicchurch.org"
       workgroups:


### PR DESCRIPTION
Turns out that we need an actual Google Account to store the WordPress backups, and wordpress-backups is a natural name for that.  So we'll make the Google Group for access to the Google Drive folders for that be wordpress-backups-access.