### PR TITLE
pk-cron-runner.yaml: increase ministry roster timeout

### DIFF
--- a/migrate-to-parishkit/configs/pk-cron-runner.yaml
+++ b/migrate-to-parishkit/configs/pk-cron-runner.yaml
@@ -31,7 +31,7 @@ jobs:
   - name: ministry-rosters
     enabled: true
     cwd: /opt/parishkit
-    timeout: 5m
+    timeout: 10m
     command:
       - pk-create-ps-ministry-rosters
       - --config


### PR DESCRIPTION
The ministry roster script runs once a day, at 2am US Eastern.  It takes more than 6-7 minutes to run, and was continually getting cut off before it could complete (leaving some ministry rosters un-updated).